### PR TITLE
Removes explicit env_file handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/compose-spec/compose-go v0.0.0-20200907084823-057e1edc5b6f
 	github.com/google/go-cmp v0.5.2
 	github.com/imdario/mergo v0.3.11
-	github.com/joho/godotenv v1.3.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -38,7 +38,6 @@ import (
 	"github.com/appvia/kube-devx/pkg/kev/config"
 	"github.com/appvia/kube-devx/pkg/kev/log"
 	composego "github.com/compose-spec/compose-go/types"
-	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
@@ -530,30 +529,6 @@ func durationStrToSecondsInt(s string) (*int32, error) {
 	return &r, nil
 }
 
-// getEnvsFromFile get env vars from env_file
-// @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/k8sutils.go#L757
-func getEnvsFromFile(file string, inputFiles []string) (map[string]string, error) {
-	// Get the correct file context / directory
-	composeDir, err := getComposeFileDir(inputFiles)
-	if err != nil {
-		log.Error("Unable to load file context")
-		return nil, err
-	}
-
-	fileLocation := path.Join(composeDir, file)
-
-	// Load environment variables from file
-	envLoad, err := godotenv.Read(fileLocation)
-	if err != nil {
-		log.ErrorWithFields(log.Fields{
-			"file": file,
-		}, "Unable to read env_file")
-		return nil, err
-	}
-
-	return envLoad, nil
-}
-
 // getContentFromFile gets the content from the file..
 // @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/k8sutils.go#L775
 func getContentFromFile(file string) (string, error) {
@@ -587,13 +562,6 @@ func rfc1123label(s string) string {
 		return s[0:62]
 	}
 	return s
-}
-
-// formatEnvFileName format env file name
-// @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/k8sutils.go#L784
-func formatEnvFileName(name string) string {
-	envName := strings.Trim(name, "./")
-	return rfc1123dns(envName)
 }
 
 // formatFileName format file name

--- a/pkg/kev/converter/kubernetes/utils_test.go
+++ b/pkg/kev/converter/kubernetes/utils_test.go
@@ -252,48 +252,6 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
-	Describe("getEnvsFromFile", func() {
-		var file string
-		var inputFilePaths []string
-
-		BeforeEach(func() {
-			file = "env_file"
-			inputFilePaths = []string{
-				"../../testdata/converter/kubernetes/dummy",
-			}
-		})
-
-		It("loads environment variables defined in the referenced env_file and returns a map", func() {
-			env, err := getEnvsFromFile(file, inputFilePaths)
-			Expect(env).To(HaveKeyWithValue("FOO", "BAR"))
-			Expect(env).To(HaveKeyWithValue("BAR", "BAZ"))
-			Expect(env).To(HaveKeyWithValue("EMPTY", ""))
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		Context("with invalid (compose) input file path", func() {
-			BeforeEach(func() {
-				inputFilePaths = []string{"/wrong/path"}
-			})
-
-			It("returns an error", func() {
-				_, err := getEnvsFromFile(file, inputFilePaths)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		Context("with invalid path to env_file", func() {
-			BeforeEach(func() {
-				file = "wrong_env_file"
-			})
-
-			It("returns an error", func() {
-				_, err := getEnvsFromFile(file, inputFilePaths)
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-
 	Describe("configLabelsWithNetwork", func() {
 		svcName := "db"
 		networkNameA := "mynetA"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,6 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/joho/godotenv v1.3.0
-## explicit
 github.com/joho/godotenv
 # github.com/json-iterator/go v1.1.8
 github.com/json-iterator/go


### PR DESCRIPTION
This PR removes explicit env_file handling as compose-go library automatically loads all environment variables defined in env_file and appends any explicitly defined env variables. compose-go discards information about the env_file used and so there is currently no need for any special env_file handling. All compose project service env variables are automatically expanded in the Kubernetes deployment definition.

Resolves #204 