### PR TITLE
Regression: Reconcile should not append a new service env vars onto an overlay. 

### DIFF
--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -77,7 +77,7 @@ func detectServicesCreate(dst *composeOverlay, src *composeOverlay, cset *change
 		if !dstSvcSet[srcSvc.Name] {
 			cset.services = append(cset.services, change{
 				Type:  CREATE,
-				Value: srcSvc,
+				Value: srcSvc.minusEnvVars(),
 			})
 		}
 	}

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -215,6 +215,10 @@ var _ = Describe("Reconcile", func() {
 					Expect(env.GetServices()[1].GetLabels()).To(Equal(expected))
 				})
 
+				It("should not include any env vars", func() {
+					Expect(env.GetServices()[1].Environment).To(HaveLen(0))
+				})
+
 				It("should create a change summary", func() {
 					Expect(reporter.String()).To(ContainSubstring(env.Name))
 					Expect(reporter.String()).To(ContainSubstring("added"))

--- a/pkg/kev/overlay.go
+++ b/pkg/kev/overlay.go
@@ -67,6 +67,15 @@ func (sc ServiceConfig) GetLabels() map[string]string {
 	return sc.Labels
 }
 
+// minusEnvVars returns a copy of the ServiceConfig with blank env vars
+func (sc ServiceConfig) minusEnvVars() ServiceConfig {
+	return ServiceConfig{
+		Name:        sc.Name,
+		Labels:      sc.Labels,
+		Environment: map[string]*string{},
+	}
+}
+
 // diff detects changes between an overlay against another overlay.
 func (o *composeOverlay) diff(other *composeOverlay) changeset {
 	return newChangeset(other, o)


### PR DESCRIPTION
Small fix, resolves #261 

