### PR TITLE
Add a verbose mode to Kev cmds, to communicate extra runtime info.

### DIFF
--- a/cmd/kev/cmd/detect.go
+++ b/cmd/kev/cmd/detect.go
@@ -23,17 +23,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func runDetectSecretsCmd(_ *cobra.Command, _ []string) error {
+func runDetectSecretsCmd(cmd *cobra.Command, _ []string) error {
 	cmdName := "Detect secrets"
+	verbose, _ := cmd.Root().Flags().GetBool("verbose")
 
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return displayError(cmdName, err)
 	}
 
-	if err := kev.DetectSecrets(workingDir, os.Stdout); err != nil {
+	reporter := getReporter(verbose)
+	if err := kev.DetectSecrets(workingDir, reporter); err != nil {
 		return displayError(cmdName, err)
 	}
+	_, _ = reporter.Write([]byte("\n"))
 
 	return nil
 }

--- a/cmd/kev/cmd/detect.go
+++ b/cmd/kev/cmd/detect.go
@@ -35,7 +35,7 @@ func runDetectSecretsCmd(cmd *cobra.Command, _ []string) error {
 	setReporting(verbose)
 	displayCmdStarted(cmdName)
 
-	if err := kev.DetectSecrets(workingDir, nil); err != nil {
+	if err := kev.DetectSecrets(workingDir); err != nil {
 		return displayError(err)
 	}
 

--- a/cmd/kev/cmd/init.go
+++ b/cmd/kev/cmd/init.go
@@ -138,7 +138,7 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 		FileName: kev.ManifestName,
 	}}, results...)
 
-	displayInitSuccess(os.Stdout, results)
+	displayInitSuccess(getReporter(true), results)
 
 	return nil
 }

--- a/cmd/kev/cmd/init.go
+++ b/cmd/kev/cmd/init.go
@@ -46,11 +46,14 @@ Examples:
   $ kev init -e staging`
 
 var initCmd = &cobra.Command{
-	Use:      "init",
-	Short:    "Tracks compose sources & creates deployment environments.",
-	Long:     initLongDesc,
-	RunE:     runInitCmd,
-	PostRunE: runDetectSecretsCmd,
+	Use:   "init",
+	Short: "Tracks compose sources & creates deployment environments.",
+	Long:  initLongDesc,
+	RunE:  runInitCmd,
+	PostRunE: func(cmd *cobra.Command, args []string) error {
+		os.Stdout.Write([]byte("\n"))
+		return runDetectSecretsCmd(cmd, args)
+	},
 }
 
 type skippableFile struct {
@@ -89,20 +92,22 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 	envs, _ := cmd.Flags().GetStringSlice("environment")
 	skaffold, _ := cmd.Flags().GetBool("skaffold")
 
+	displayCmdStarted(cmdName)
+
 	workingDirAbs, err := os.Getwd()
 	if err != nil {
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
 	manifestPath := path.Join(workingDirAbs, kev.ManifestName)
 	if manifestExistsForPath(manifestPath) {
 		err := fmt.Errorf("kev.yaml already exists at: %s", manifestPath)
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
 	manifest, err := kev.Init(files, envs, ".")
 	if err != nil {
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
 	var results []skippableFile
@@ -111,7 +116,7 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 		envPath := path.Join(workingDirAbs, environment.File)
 
 		if err := writeTo(envPath, environment); err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 
 		results = append(results, skippableFile{
@@ -126,19 +131,19 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 		manifest.Skaffold = kev.SkaffoldFileName
 
 		if err := createOrUpdateSkaffoldManifest(skaffoldManifestPath, envs, &results); err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 	}
 
 	if err := writeTo(manifestPath, manifest); err != nil {
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
 	results = append([]skippableFile{{
 		FileName: kev.ManifestName,
 	}}, results...)
 
-	displayInitSuccess(getReporter(true), results)
+	displayInitSuccess(os.Stdout, results)
 
 	return nil
 }
@@ -160,8 +165,6 @@ func writeTo(filePath string, w io.WriterTo) error {
 }
 
 func createOrUpdateSkaffoldManifest(path string, envs []string, results *[]skippableFile) error {
-	cmdName := "Init"
-
 	if manifestExistsForPath(path) {
 		// skaffold manifest already present - add additional profiles to it!
 		// Note: kev will skip profiles with names matching those of existing
@@ -169,10 +172,10 @@ func createOrUpdateSkaffoldManifest(path string, envs []string, results *[]skipp
 
 		updatedSkaffold, err := kev.AddProfiles(path, envs, true)
 		if err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 		if err := writeTo(path, updatedSkaffold); err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 
 		*results = append(*results, skippableFile{
@@ -184,11 +187,11 @@ func createOrUpdateSkaffoldManifest(path string, envs []string, results *[]skipp
 
 		skaffoldManifest, err := kev.PrepareForSkaffold(envs)
 		if err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 
 		if err := writeTo(kev.SkaffoldFileName, skaffoldManifest); err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 
 		*results = append(*results, skippableFile{

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -30,19 +30,21 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
-	reporter := getReporter(verbose)
-	manifest, err := kev.Reconcile(workingDir, reporter)
+	setReporting(verbose)
+	displayCmdStarted(cmdName)
+
+	manifest, err := kev.Reconcile(workingDir, nil)
 	if err != nil {
-		return displayError(cmdName, err)
+		return displayError(err)
 	}
 
 	for _, environment := range manifest.Environments {
 		filePath := path.Join(workingDir, environment.File)
 		if err := writeTo(filePath, environment); err != nil {
-			return displayError(cmdName, err)
+			return displayError(err)
 		}
 	}
 

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -24,20 +24,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func runReconcileCmd(_ *cobra.Command, _ []string) error {
+func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 	cmdName := "Reconcile"
+	verbose, _ := cmd.Root().Flags().GetBool("verbose")
 
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return displayError(cmdName, err)
 	}
 
-	manifest, err := kev.Reconcile(workingDir, os.Stdout)
+	reporter := getReporter(verbose)
+	manifest, err := kev.Reconcile(workingDir, reporter)
 	if err != nil {
 		return displayError(cmdName, err)
 	}
-
-	os.Stdout.WriteString("...............................\n\n")
 
 	for _, environment := range manifest.Environments {
 		filePath := path.Join(workingDir, environment.File)

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -36,7 +36,7 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 	setReporting(verbose)
 	displayCmdStarted(cmdName)
 
-	manifest, err := kev.Reconcile(workingDir, nil)
+	manifest, err := kev.Reconcile(workingDir)
 	if err != nil {
 		return displayError(err)
 	}

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -17,9 +17,7 @@
 package cmd
 
 import (
-	"fmt"
-	"io/ioutil"
-	"strings"
+	"os"
 
 	"github.com/appvia/kev/pkg/kev"
 	"github.com/appvia/kev/pkg/kev/log"
@@ -49,6 +47,7 @@ var renderCmd = &cobra.Command{
 			if err := fn(cmd, args); err != nil {
 				return err
 			}
+			os.Stdout.Write([]byte("\n"))
 		}
 		return nil
 	},
@@ -91,6 +90,8 @@ func init() {
 }
 
 func runRenderCmd(cmd *cobra.Command, _ []string) error {
+	cmdName := "Render"
+
 	format, err := cmd.Flags().GetString("format")
 	singleFile, err := cmd.Flags().GetBool("single")
 	dir, err := cmd.Flags().GetString("dir")
@@ -101,16 +102,12 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	reporter := getReporter(true)
-	if !verbose {
-		log.SetOutput(ioutil.Discard)
-	}
-
-	_, _ = reporter.Write([]byte("✓ Render\n"))
+	setReporting(verbose)
+	displayCmdStarted(cmdName)
+	log.DebugTitlef("Output format: %s", format)
 	if err := kev.Render(format, singleFile, dir, envs); err != nil {
 		return err
 	}
-	_, _ = reporter.Write([]byte(fmt.Sprintf(" → Rendering manifests in %s output format ... Done\n", strings.Title(format))))
 
 	return nil
 }

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -17,6 +17,10 @@
 package cmd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
 	"github.com/appvia/kev/pkg/kev"
 	"github.com/appvia/kev/pkg/kev/log"
 	"github.com/spf13/cobra"
@@ -91,18 +95,22 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 	singleFile, err := cmd.Flags().GetBool("single")
 	dir, err := cmd.Flags().GetString("dir")
 	envs, err := cmd.Flags().GetStringSlice("environment")
+	verbose, _ := cmd.Root().Flags().GetBool("verbose")
 
 	if err != nil {
 		return err
 	}
 
-	log.Infof("⚙️  Output format: %s", format)
+	reporter := getReporter(true)
+	if !verbose {
+		log.SetOutput(ioutil.Discard)
+	}
 
+	_, _ = reporter.Write([]byte("✓ Render\n"))
 	if err := kev.Render(format, singleFile, dir, envs); err != nil {
 		return err
 	}
-
-	log.Info("🧰 App render complete!")
+	_, _ = reporter.Write([]byte(fmt.Sprintf(" → Rendering manifests in %s output format ... Done\n", strings.Title(format))))
 
 	return nil
 }

--- a/cmd/kev/cmd/root.go
+++ b/cmd/kev/cmd/root.go
@@ -26,10 +26,11 @@ import (
 
 var silentErr = errors.New("silentErr")
 var rootCmd = &cobra.Command{
-	Use:           "kev",
-	Short:         "Develop Kubernetes apps iteratively using Docker-Compose.",
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:              "kev",
+	Short:            "Develop Kubernetes apps iteratively using Docker-Compose.",
+	TraverseChildren: true,
+	SilenceErrors:    true,
+	SilenceUsage:     true,
 }
 
 // NewRootCmd returns root command
@@ -38,6 +39,16 @@ func NewRootCmd() *cobra.Command {
 }
 
 func init() {
+	flags := rootCmd.Flags()
+	flags.SortFlags = false
+
+	flags.BoolP(
+		"verbose",
+		"v",
+		false,
+		"Show more output",
+	)
+
 	// This is required to help with error handling from RunE , https://github.com/spf13/cobra/issues/914#issuecomment-548411337
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.Println(err)

--- a/cmd/kev/cmd/root.go
+++ b/cmd/kev/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -60,9 +59,6 @@ func init() {
 // Execute command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		if err != silentErr {
-			fmt.Fprintln(os.Stderr, err)
-		}
 		os.Exit(1)
 	}
 }

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -19,25 +19,29 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
+
+	"github.com/appvia/kev/pkg/kev/log"
+	"github.com/sirupsen/logrus"
 )
 
-func getReporter(onScreen bool) io.Writer {
-	out := ioutil.Discard
-	if onScreen {
-		out = os.Stdout
+func setReporting(verbose bool) {
+	log.SetLogLevel(logrus.InfoLevel)
+	if verbose {
+		log.SetLogLevel(logrus.DebugLevel)
 	}
-	return out
 }
 
-func displayError(cmdName string, err error) error {
-	_, _ = os.Stdout.Write([]byte("⨯ " + cmdName + "\n"))
-	return fmt.Errorf(" → Error: %s", err)
+func displayCmdStarted(cmdName string) {
+	_, _ = os.Stdout.Write([]byte("᛬" + cmdName + " ...\n"))
+}
+
+func displayError(err error) error {
+	log.ErrorDetail(err)
+	return err
 }
 
 func displayInitSuccess(w io.Writer, files []skippableFile) {
-	_, _ = w.Write([]byte("✓ Init\n"))
 	for _, file := range files {
 		msg := fmt.Sprintf(" → Creating %s ... Done\n", file.FileName)
 

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -19,8 +19,17 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 )
+
+func getReporter(onScreen bool) io.Writer {
+	out := ioutil.Discard
+	if onScreen {
+		out = os.Stdout
+	}
+	return out
+}
 
 func displayError(cmdName string, err error) error {
 	_, _ = os.Stdout.Write([]byte("⨯ " + cmdName + "\n"))

--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -17,11 +17,11 @@
 package kev
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 
 	"github.com/appvia/kev/pkg/kev/config"
+	"github.com/appvia/kev/pkg/kev/log"
 )
 
 const (
@@ -201,7 +201,8 @@ func (chg change) patchVersion(override *composeOverride, reporter io.Writer) {
 	pre := override.Version
 	newValue := chg.Value.(string)
 	override.Version = newValue
-	_, _ = reporter.Write([]byte(fmt.Sprintf(" → version updated, from:[%s] to:[%s]\n", pre, newValue)))
+	// _, _ = reporter.Write([]byte(fmt.Sprintf(" → version updated, from:[%s] to:[%s]\n", pre, newValue)))
+	log.DebugDetailf("version updated, from:[%s] to:[%s]", pre, newValue)
 }
 
 func (chg change) patchService(override *composeOverride, reporter io.Writer) {
@@ -209,16 +210,19 @@ func (chg change) patchService(override *composeOverride, reporter io.Writer) {
 	case CREATE:
 		newValue := chg.Value.(ServiceConfig).condenseLabels(config.BaseServiceLabels)
 		override.Services = append(override.Services, newValue)
-		_, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s] added\n", newValue.Name)))
+		// _, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s] added\n", newValue.Name)))
+		log.DebugDetailf("service [%s] added", newValue.Name)
 	case DELETE:
 		switch {
 		case chg.Parent == "environment":
 			delete(override.Services[chg.Index.(int)].Environment, chg.Target)
-			_, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s], env var [%s] deleted\n", override.Services[chg.Index.(int)].Name, chg.Target)))
+			// _, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s], env var [%s] deleted\n", override.Services[chg.Index.(int)].Name, chg.Target)))
+			log.DebugDetailf("service [%s], env var [%s] deleted", override.Services[chg.Index.(int)].Name, chg.Target)
 		default:
 			deletedSvcName := override.Services[chg.Index.(int)].Name
 			override.Services = append(override.Services[:chg.Index.(int)], override.Services[chg.Index.(int)+1:]...)
-			_, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s] deleted\n", deletedSvcName)))
+			// _, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s] deleted\n", deletedSvcName)))
+			log.DebugDetailf("service [%s] deleted", deletedSvcName)
 		}
 	case UPDATE:
 		if chg.Parent == "labels" {
@@ -226,7 +230,8 @@ func (chg change) patchService(override *composeOverride, reporter io.Writer) {
 			newValue := chg.Value.(string)
 			override.Services[chg.Index.(int)].Labels[chg.Target] = newValue
 			if canUpdate {
-				_, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s], label [%s] updated, from:[%s] to:[%s]\n", override.Services[chg.Index.(int)].Name, chg.Target, pre, newValue)))
+				// _, _ = reporter.Write([]byte(fmt.Sprintf(" → service [%s], label [%s] updated, from:[%s] to:[%s]\n", override.Services[chg.Index.(int)].Name, chg.Target, pre, newValue)))
+				log.DebugDetailf("service [%s], label [%s] updated, from:[%s] to:[%s]", override.Services[chg.Index.(int)].Name, chg.Target, pre, newValue)
 			}
 		}
 	}
@@ -237,9 +242,11 @@ func (chg change) patchVolume(override *composeOverride, reporter io.Writer) {
 	case CREATE:
 		newValue := chg.Value.(VolumeConfig).condenseLabels(config.BaseVolumeLabels)
 		override.Volumes[chg.Index.(string)] = newValue
-		_, _ = reporter.Write([]byte(fmt.Sprintf(" → volume [%s] added\n", chg.Index.(string))))
+		// _, _ = reporter.Write([]byte(fmt.Sprintf(" → volume [%s] added\n", chg.Index.(string))))
+		log.DebugDetailf("volume [%s] added", chg.Index.(string))
 	case DELETE:
 		delete(override.Volumes, chg.Index.(string))
-		_, _ = reporter.Write([]byte(fmt.Sprintf(" → volume [%s] deleted\n", chg.Index.(string))))
+		// _, _ = reporter.Write([]byte(fmt.Sprintf(" → volume [%s] deleted\n", chg.Index.(string))))
+		log.DebugDetailf("volume [%s] deleted", chg.Index.(string))
 	}
 }

--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -200,7 +200,7 @@ func (chg change) patchVersion(override *composeOverride) {
 	pre := override.Version
 	newValue := chg.Value.(string)
 	override.Version = newValue
-	log.DebugDetailf("version updated, from:[%s] to:[%s]", pre, newValue)
+	log.Debugf("version updated, from:[%s] to:[%s]", pre, newValue)
 }
 
 func (chg change) patchService(override *composeOverride) {
@@ -208,16 +208,16 @@ func (chg change) patchService(override *composeOverride) {
 	case CREATE:
 		newValue := chg.Value.(ServiceConfig).condenseLabels(config.BaseServiceLabels)
 		override.Services = append(override.Services, newValue)
-		log.DebugDetailf("service [%s] added", newValue.Name)
+		log.Debugf("service [%s] added", newValue.Name)
 	case DELETE:
 		switch {
 		case chg.Parent == "environment":
 			delete(override.Services[chg.Index.(int)].Environment, chg.Target)
-			log.DebugDetailf("service [%s], env var [%s] deleted", override.Services[chg.Index.(int)].Name, chg.Target)
+			log.Debugf("service [%s], env var [%s] deleted", override.Services[chg.Index.(int)].Name, chg.Target)
 		default:
 			deletedSvcName := override.Services[chg.Index.(int)].Name
 			override.Services = append(override.Services[:chg.Index.(int)], override.Services[chg.Index.(int)+1:]...)
-			log.DebugDetailf("service [%s] deleted", deletedSvcName)
+			log.Debugf("service [%s] deleted", deletedSvcName)
 		}
 	case UPDATE:
 		if chg.Parent == "labels" {
@@ -225,7 +225,7 @@ func (chg change) patchService(override *composeOverride) {
 			newValue := chg.Value.(string)
 			override.Services[chg.Index.(int)].Labels[chg.Target] = newValue
 			if canUpdate {
-				log.DebugDetailf("service [%s], label [%s] updated, from:[%s] to:[%s]", override.Services[chg.Index.(int)].Name, chg.Target, pre, newValue)
+				log.Debugf("service [%s], label [%s] updated, from:[%s] to:[%s]", override.Services[chg.Index.(int)].Name, chg.Target, pre, newValue)
 			}
 		}
 	}
@@ -236,9 +236,9 @@ func (chg change) patchVolume(override *composeOverride) {
 	case CREATE:
 		newValue := chg.Value.(VolumeConfig).condenseLabels(config.BaseVolumeLabels)
 		override.Volumes[chg.Index.(string)] = newValue
-		log.DebugDetailf("volume [%s] added", chg.Index.(string))
+		log.Debugf("volume [%s] added", chg.Index.(string))
 	case DELETE:
 		delete(override.Volumes, chg.Index.(string))
-		log.DebugDetailf("volume [%s] deleted", chg.Index.(string))
+		log.Debugf("volume [%s] deleted", chg.Index.(string))
 	}
 }

--- a/pkg/kev/converter/kubernetes/converter.go
+++ b/pkg/kev/converter/kubernetes/converter.go
@@ -47,7 +47,7 @@ func (c *K8s) Render(singleFile bool, dir, workDir string, projects map[string]*
 	renderOutputPaths := map[string]string{}
 
 	for env, project := range projects {
-		log.Infof("🖨️  Rendering %s environment", env)
+		log.DebugDetailf("Rendering environment [%s]", env)
 
 		// @step override output directory if specified
 		outDirPath := ""

--- a/pkg/kev/converter/kubernetes/converter.go
+++ b/pkg/kev/converter/kubernetes/converter.go
@@ -47,7 +47,7 @@ func (c *K8s) Render(singleFile bool, dir, workDir string, projects map[string]*
 	renderOutputPaths := map[string]string{}
 
 	for env, project := range projects {
-		log.DebugDetailf("Rendering environment [%s]", env)
+		log.Debugf("Rendering environment [%s]", env)
 
 		// @step override output directory if specified
 		outDirPath := ""

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -149,7 +149,7 @@ func (k *Kubernetes) Transform() ([]runtime.Object, error) {
 		// @step create network policies if networks defined
 		if len(projectService.Networks) > 0 {
 			for name := range projectService.Networks {
-				log.DebugDetailWithFields(log.Fields{
+				log.DebugWithFields(log.Fields{
 					"project-service": projectService.Name,
 					"network-name":    name,
 				}, "Network detected and will be converted to equivalent NetworkPolicy")
@@ -1128,7 +1128,7 @@ func (k *Kubernetes) configVolumes(projectService ProjectService) ([]v1.VolumeMo
 				}
 			}
 		} else {
-			log.DebugDetailWithFields(log.Fields{
+			log.DebugWithFields(log.Fields{
 				"project-service": projectService.Name,
 			}, "Use PVC volume")
 
@@ -1762,7 +1762,7 @@ func (k *Kubernetes) removeDupObjects(objs *[]runtime.Object) {
 		if us, ok := obj.(meta.Object); ok {
 			k := obj.GetObjectKind().GroupVersionKind().String() + us.GetNamespace() + us.GetName()
 			if exist[k] {
-				log.DebugDetailfWithFields(log.Fields{
+				log.DebugfWithFields(log.Fields{
 					"configmap": us.GetName(),
 				}, "Remove duplicate resource: %s/%s", obj.GetObjectKind().GroupVersionKind().Kind, us.GetName())
 

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -149,7 +149,7 @@ func (k *Kubernetes) Transform() ([]runtime.Object, error) {
 		// @step create network policies if networks defined
 		if len(projectService.Networks) > 0 {
 			for name := range projectService.Networks {
-				log.DebugWithFields(log.Fields{
+				log.DebugDetailWithFields(log.Fields{
 					"project-service": projectService.Name,
 					"network-name":    name,
 				}, "Network detected and will be converted to equivalent NetworkPolicy")
@@ -1128,7 +1128,7 @@ func (k *Kubernetes) configVolumes(projectService ProjectService) ([]v1.VolumeMo
 				}
 			}
 		} else {
-			log.DebugWithFields(log.Fields{
+			log.DebugDetailWithFields(log.Fields{
 				"project-service": projectService.Name,
 			}, "Use PVC volume")
 
@@ -1762,7 +1762,7 @@ func (k *Kubernetes) removeDupObjects(objs *[]runtime.Object) {
 		if us, ok := obj.(meta.Object); ok {
 			k := obj.GetObjectKind().GroupVersionKind().String() + us.GetNamespace() + us.GetName()
 			if exist[k] {
-				log.DebugfWithFields(log.Fields{
+				log.DebugDetailfWithFields(log.Fields{
 					"configmap": us.GetName(),
 				}, "Remove duplicate resource: %s/%s", obj.GetObjectKind().GroupVersionKind().Kind, us.GetName())
 

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -79,7 +79,7 @@ func PrintList(objects []runtime.Object, opt ConvertOptions, rendered map[string
 
 	var f *os.File
 	dirName := getDirName(opt)
-	log.DebugDetailf("Target Dir: %s", dirName)
+	log.Debugf("Target Dir: %s", dirName)
 
 	// Check if output file is a directory
 	isDirVal, err := isDir(opt.OutFile)
@@ -244,7 +244,7 @@ func print(name, path string, trailing string, data []byte, toStdout, generateJS
 			}, "Failed to write content to a file")
 			return "", err
 		}
-		log.DebugDetailf("%s file %q created", Name, file)
+		log.Debugf("%s file %q created", Name, file)
 	}
 	return file, nil
 }

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -79,7 +79,7 @@ func PrintList(objects []runtime.Object, opt ConvertOptions, rendered map[string
 
 	var f *os.File
 	dirName := getDirName(opt)
-	log.Infof("Target Dir: %s", dirName)
+	log.DebugDetailf("Target Dir: %s", dirName)
 
 	// Check if output file is a directory
 	isDirVal, err := isDir(opt.OutFile)
@@ -244,7 +244,7 @@ func print(name, path string, trailing string, data []byte, toStdout, generateJS
 			}, "Failed to write content to a file")
 			return "", err
 		}
-		log.Infof("⎈  %s file %q created", Name, file)
+		log.DebugDetailf("%s file %q created", Name, file)
 	}
 	return file, nil
 }

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -162,7 +162,7 @@ func (e *Environment) reconcile(override *composeOverride) error {
 	labelsMatching := override.toLabelsMatching(e.override)
 	cset := labelsMatching.diff(e.override)
 	if cset.HasNoPatches() {
-		log.DebugDetail("nothing to update")
+		log.Debug("nothing to update")
 		return nil
 	}
 

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -18,10 +18,10 @@ package kev
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"sort"
 
+	"github.com/appvia/kev/pkg/kev/log"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -157,12 +157,14 @@ func (e *Environment) loadOverride() (*Environment, error) {
 }
 
 func (e *Environment) reconcile(override *composeOverride, reporter io.Writer) error {
-	_, _ = reporter.Write([]byte(fmt.Sprintf("✓ Reconciling environment [%s]\n", e.Name)))
+	// _, _ = reporter.Write([]byte(fmt.Sprintf("✓ Reconciling environment [%s]\n", e.Name)))
+	log.DebugTitlef("Reconciling environment [%s]", e.Name)
 
 	labelsMatching := override.toLabelsMatching(e.override)
 	cset := labelsMatching.diff(e.override)
 	if cset.HasNoPatches() {
-		_, _ = reporter.Write([]byte(fmt.Sprint(" → nothing to update\n")))
+		// _, _ = reporter.Write([]byte(fmt.Sprint(" → nothing to update\n")))
+		log.DebugDetail("nothing to update")
 		return nil
 	}
 

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -156,24 +156,22 @@ func (e *Environment) loadOverride() (*Environment, error) {
 	return e, nil
 }
 
-func (e *Environment) reconcile(override *composeOverride, reporter io.Writer) error {
-	// _, _ = reporter.Write([]byte(fmt.Sprintf("✓ Reconciling environment [%s]\n", e.Name)))
+func (e *Environment) reconcile(override *composeOverride) error {
 	log.DebugTitlef("Reconciling environment [%s]", e.Name)
 
 	labelsMatching := override.toLabelsMatching(e.override)
 	cset := labelsMatching.diff(e.override)
 	if cset.HasNoPatches() {
-		// _, _ = reporter.Write([]byte(fmt.Sprint(" → nothing to update\n")))
 		log.DebugDetail("nothing to update")
 		return nil
 	}
 
-	e.patch(cset, reporter)
+	e.patch(cset)
 	return nil
 }
 
-func (e *Environment) patch(cset changeset, reporter io.Writer) {
-	e.override.patch(cset, reporter)
+func (e *Environment) patch(cset changeset) {
+	e.override.patch(cset)
 }
 
 func (e *Environment) prepareForMergeUsing(override *composeOverride) {

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -17,7 +17,6 @@
 package kev
 
 import (
-	"io"
 	"os"
 
 	"github.com/appvia/kev/pkg/kev/config"
@@ -60,12 +59,12 @@ func PrepareForSkaffold(envs []string) (*SkaffoldManifest, error) {
 }
 
 // Reconcile reconciles changes with docker-compose sources against deployment environments.
-func Reconcile(workingDir string, reporter io.Writer) (*Manifest, error) {
+func Reconcile(workingDir string) (*Manifest, error) {
 	m, err := LoadManifest(workingDir)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := m.ReconcileConfig(reporter); err != nil {
+	if _, err := m.ReconcileConfig(); err != nil {
 		return nil, errors.Wrap(err, "Could not reconcile project latest")
 	}
 	return m, err
@@ -73,14 +72,14 @@ func Reconcile(workingDir string, reporter io.Writer) (*Manifest, error) {
 
 // DetectSecrets detects any potential secrets defined in environment variables
 // found either in sources or override environments.
-// Any detected secrets are reported back using the supplied reporter.
-func DetectSecrets(workingDir string, reporter io.Writer) error {
+// Any detected secrets are logged using a warning log level.
+func DetectSecrets(workingDir string) error {
 	m, err := LoadManifest(workingDir)
 	if err != nil {
 		return err
 	}
-	m.DetectSecretsInSources(config.SecretMatchers, reporter)
-	m.DetectSecretsInEnvs(config.SecretMatchers, reporter)
+	m.DetectSecretsInSources(config.SecretMatchers)
+	m.DetectSecretsInEnvs(config.SecretMatchers)
 	return nil
 }
 

--- a/pkg/kev/kev_detect_test.go
+++ b/pkg/kev/kev_detect_test.go
@@ -20,19 +20,28 @@ import (
 	"bytes"
 
 	"github.com/appvia/kev/pkg/kev"
+	"github.com/appvia/kev/pkg/kev/testutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 )
 
 var _ = Describe("Detect", func() {
 	var (
+		hook       *test.Hook
 		workingDir string
 		reporter   bytes.Buffer
 		dErr       error
 	)
 
 	JustBeforeEach(func() {
+		hook = testutil.NewLogger(logrus.InfoLevel)
 		dErr = kev.DetectSecrets(workingDir, &reporter)
+	})
+
+	JustAfterEach(func() {
+		hook.Reset()
 	})
 
 	BeforeEach(func() {
@@ -44,21 +53,25 @@ var _ = Describe("Detect", func() {
 		Expect(dErr).ShouldNot(HaveOccurred())
 	})
 
+	It("should log the detected secrets summary using the warning level", func() {
+		Expect(testutil.GetLoggedLevel(hook)).To(Equal("warning"))
+	})
+
 	When("secrets leaked as environment variables in sources", func() {
 		It("should create a detected leaks summary", func() {
-			Expect(reporter.String()).Should(ContainSubstring("MYSQL_ROOT_PASSWORD"))
-			Expect(reporter.String()).Should(ContainSubstring("MYSQL_USER"))
-			Expect(reporter.String()).Should(ContainSubstring("MYSQL_PASSWORD"))
-			Expect(reporter.String()).Should(ContainSubstring("WORDPRESS_DB_USER"))
-			Expect(reporter.String()).Should(ContainSubstring("WORDPRESS_DB_PASSWORD"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("MYSQL_ROOT_PASSWORD"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("MYSQL_USER"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("MYSQL_PASSWORD"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("WORDPRESS_DB_USER"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("WORDPRESS_DB_PASSWORD"))
 		})
 	})
 
 	When("secrets leaked as environment variables in overridden environments", func() {
 		It("should create a detected leaks summary", func() {
-			Expect(reporter.String()).Should(ContainSubstring("AWS_ACCESS_KEY_ID"))
-			Expect(reporter.String()).Should(ContainSubstring("AWS_SECRET_ACCESS_KEY"))
-			Expect(reporter.String()).ShouldNot(ContainSubstring("CACHE_SWITCH"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("AWS_ACCESS_KEY_ID"))
+			Expect(testutil.GetLoggedMsgs(hook)).Should(ContainSubstring("AWS_SECRET_ACCESS_KEY"))
+			Expect(testutil.GetLoggedMsgs(hook)).ShouldNot(ContainSubstring("CACHE_SWITCH"))
 		})
 	})
 })

--- a/pkg/kev/kev_detect_test.go
+++ b/pkg/kev/kev_detect_test.go
@@ -17,8 +17,6 @@
 package kev_test
 
 import (
-	"bytes"
-
 	"github.com/appvia/kev/pkg/kev"
 	"github.com/appvia/kev/pkg/kev/testutil"
 	. "github.com/onsi/ginkgo"
@@ -31,13 +29,12 @@ var _ = Describe("Detect", func() {
 	var (
 		hook       *test.Hook
 		workingDir string
-		reporter   bytes.Buffer
 		dErr       error
 	)
 
 	JustBeforeEach(func() {
 		hook = testutil.NewLogger(logrus.InfoLevel)
-		dErr = kev.DetectSecrets(workingDir, &reporter)
+		dErr = kev.DetectSecrets(workingDir)
 	})
 
 	JustAfterEach(func() {
@@ -46,7 +43,6 @@ var _ = Describe("Detect", func() {
 
 	BeforeEach(func() {
 		workingDir = "testdata/detect-secrets"
-		reporter = bytes.Buffer{}
 	})
 
 	It("should not error", func() {

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -17,8 +17,6 @@
 package kev_test
 
 import (
-	"bytes"
-
 	"github.com/appvia/kev/pkg/kev"
 	"github.com/appvia/kev/pkg/kev/config"
 	"github.com/appvia/kev/pkg/kev/testutil"
@@ -31,7 +29,6 @@ import (
 var _ = Describe("Reconcile", func() {
 	var (
 		hook          *test.Hook
-		reporter      bytes.Buffer
 		loggedMsgs    string
 		workingDir    string
 		source        *kev.ComposeProject
@@ -47,7 +44,7 @@ var _ = Describe("Reconcile", func() {
 			override, _ = kev.NewComposeProject(overrideFiles)
 		}
 		hook = testutil.NewLogger(logrus.DebugLevel)
-		manifest, mErr = kev.Reconcile(workingDir, &reporter)
+		manifest, mErr = kev.Reconcile(workingDir)
 		if mErr == nil {
 			env, _ = manifest.GetEnvironment("dev")
 		}
@@ -64,7 +61,6 @@ var _ = Describe("Reconcile", func() {
 				workingDir = "testdata/reconcile-override-rollback"
 				source, _ = kev.NewComposeProject([]string{workingDir + "/docker-compose.yaml"})
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the version pre reconciliation", func() {
@@ -80,7 +76,7 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-override-keep"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
+
 			})
 
 			When("the override service label overrides have been updated", func() {
@@ -123,7 +119,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-version"
 				source, _ = kev.NewComposeProject([]string{workingDir + "/docker-compose.yaml"})
-				reporter = bytes.Buffer{}
 			})
 
 			It("should update all environments with the new version", func() {
@@ -150,7 +145,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-service-removal"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the number of services pre reconciliation", func() {
@@ -182,7 +176,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-service-edit"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			Context("and it changes port mode to host", func() {
@@ -220,7 +213,6 @@ var _ = Describe("Reconcile", func() {
 				BeforeEach(func() {
 					workingDir = "testdata/reconcile-service-basic"
 					overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-					reporter = bytes.Buffer{}
 				})
 
 				It("confirms the number of services pre reconciliation", func() {
@@ -287,7 +279,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-volume-add"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the number of volumes pre reconciliation", func() {
@@ -321,7 +312,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-volume-removal"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the number of volumes pre reconciliation", func() {
@@ -351,7 +341,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-volume-edit"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the volume name pre reconciliation", func() {
@@ -385,7 +374,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-env-var-removal"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the env vars pre reconciliation", func() {
@@ -425,7 +413,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-env-var-override"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("confirms the overridden env var pre reconciliation", func() {
@@ -458,7 +445,6 @@ var _ = Describe("Reconcile", func() {
 			BeforeEach(func() {
 				workingDir = "testdata/reconcile-env-var-unassigned"
 				overrideFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
-				reporter = bytes.Buffer{}
 			})
 
 			It("should not error", func() {

--- a/pkg/kev/log/log.go
+++ b/pkg/kev/log/log.go
@@ -38,9 +38,6 @@ const (
 	// detailPrefix debug log level prefix for info, debug, error, using unicode to ensure a visual on screen.
 	detailPrefix = " → "
 
-	// DebugPrefix debug log level prefix
-	DebugPrefix = "🔎"
-
 	// InfoPrefix info log level prefix
 	InfoPrefix = "💡"
 
@@ -117,24 +114,24 @@ func DebugTitlef(m string, args ...interface{}) {
 	logger.WithFields(decorate("debug-title")).Debugf(m, args...)
 }
 
-// DebugDetail logs a Debug message
-func DebugDetail(args ...interface{}) {
-	logger.WithFields(decorate("debug-detail")).Debug(args...)
+// Debug logs a Debug message
+func Debug(args ...interface{}) {
+	logger.WithFields(decorate("debug")).Debug(args...)
 }
 
-// DebugDetailf logs a Debug message
-func DebugDetailf(m string, args ...interface{}) {
-	logger.WithFields(decorate("debug-detail")).Debugf(m, args...)
+// Debugf logs a Debug message
+func Debugf(m string, args ...interface{}) {
+	logger.WithFields(decorate("debug")).Debugf(m, args...)
 }
 
-// DebugDetailWithFields logs a Debug message with fields
-func DebugDetailWithFields(f Fields, args ...interface{}) {
-	logger.WithFields(decorate("debug-detail", f)).Debug(args...)
+// DebugWithFields logs a Debug message with fields
+func DebugWithFields(f Fields, args ...interface{}) {
+	logger.WithFields(decorate("debug", f)).Debug(args...)
 }
 
-// DebugDetailfWithFields logs a Debug message with fields
-func DebugDetailfWithFields(f Fields, m string, args ...interface{}) {
-	logger.WithFields(decorate("debug-detail", f)).Debugf(m, args...)
+// DebugfWithFields logs a Debug message with fields
+func DebugfWithFields(f Fields, m string, args ...interface{}) {
+	logger.WithFields(decorate("debug", f)).Debugf(m, args...)
 }
 
 // ErrorDetailf logs an Error message
@@ -145,26 +142,6 @@ func ErrorDetail(args ...interface{}) {
 // ErrorDetailf logs an Error message
 func ErrorDetailf(m string, args ...interface{}) {
 	logger.WithFields(decorate("error-detail")).Errorf(m, args...)
-}
-
-// Debug logs a Debug message
-func Debug(args ...interface{}) {
-	logger.WithFields(decorate("debug")).Debug(args...)
-}
-
-// DebugWithFields logs a Debug message with fields
-func DebugWithFields(f Fields, args ...interface{}) {
-	logger.WithFields(decorate("debug", f)).Debug(args...)
-}
-
-// Debugf logs a Debug message
-func Debugf(m string, args ...interface{}) {
-	logger.WithFields(decorate("debug")).Debugf(m, args...)
-}
-
-// DebugfWithFields logs a Debug message with fields
-func DebugfWithFields(f Fields, m string, args ...interface{}) {
-	logger.WithFields(decorate("debug", f)).Debugf(m, args...)
 }
 
 // Info logs a Info message
@@ -258,12 +235,10 @@ func decorate(level string, f ...Fields) logrus.Fields {
 		switch level {
 		case "debug-title":
 			fields["prefix"] = successTitlePrefix
-		case "debug-detail":
+		case "debug":
 			fields["prefix"] = detailPrefix
 		case "error-detail":
 			fields["prefix"] = errorDetailPrefix
-		case "debug":
-			fields["prefix"] = DebugPrefix
 		case "info":
 			fields["prefix"] = InfoPrefix
 		case "error":

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -128,13 +128,13 @@ func (m *Manifest) GetEnvironmentFileNameTemplate() string {
 }
 
 // ReconcileConfig reconciles config changes with docker-compose sources against deployment environments.
-func (m *Manifest) ReconcileConfig(reporter io.Writer) (*Manifest, error) {
+func (m *Manifest) ReconcileConfig() (*Manifest, error) {
 	if _, err := m.CalculateSourcesBaseOverride(withEnvVars); err != nil {
 		return nil, err
 	}
 	sourcesOverride := m.getSourcesOverride()
 	for _, e := range m.Environments {
-		if err := e.reconcile(sourcesOverride, reporter); err != nil {
+		if err := e.reconcile(sourcesOverride); err != nil {
 			return nil, err
 		}
 	}
@@ -158,7 +158,7 @@ func (m *Manifest) MergeEnvIntoSources(e *Environment) (*ComposeProject, error) 
 }
 
 // DetectSecretsInSources detects any potential secrets setup as environment variables in a manifests sources.
-func (m *Manifest) DetectSecretsInSources(matchers []map[string]string, reporter io.Writer) error {
+func (m *Manifest) DetectSecretsInSources(matchers []map[string]string) error {
 	sourcesFiles := m.GetSourcesFiles()
 	p, err := NewComposeProject(sourcesFiles)
 	if err != nil {
@@ -170,7 +170,7 @@ func (m *Manifest) DetectSecretsInSources(matchers []map[string]string, reporter
 		candidates = append(candidates, ServiceConfig{Name: s.Name, Environment: s.Environment})
 	}
 
-	detected := candidates.detectSecrets(matchers, reporter, func() {
+	detected := candidates.detectSecrets(matchers, func() {
 		log.Warnf("Detected potential secrets in sources %s", sourcesFiles)
 	})
 
@@ -183,7 +183,7 @@ func (m *Manifest) DetectSecretsInSources(matchers []map[string]string, reporter
 
 // DetectSecretsInEnvs detects any potential secrets setup as environment variables
 // in a manifests deployment environments config.
-func (m *Manifest) DetectSecretsInEnvs(matchers []map[string]string, reporter io.Writer) error {
+func (m *Manifest) DetectSecretsInEnvs(matchers []map[string]string) error {
 	var filter []string
 	envs, err := m.GetEnvironments(filter)
 	if err != nil {
@@ -191,7 +191,7 @@ func (m *Manifest) DetectSecretsInEnvs(matchers []map[string]string, reporter io
 	}
 
 	for _, env := range envs {
-		detected := env.GetServices().detectSecrets(matchers, reporter, func() {
+		detected := env.GetServices().detectSecrets(matchers, func() {
 			log.Warnf("Detected potential secrets in env [%s]", env.Name)
 		})
 		if !detected {

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -175,7 +175,7 @@ func (m *Manifest) DetectSecretsInSources(matchers []map[string]string) error {
 	})
 
 	if !detected {
-		log.DebugDetail("No secrets detected in project sources")
+		log.Debug("No secrets detected in project sources")
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func (m *Manifest) DetectSecretsInEnvs(matchers []map[string]string) error {
 			log.Warnf("Detected potential secrets in env [%s]", env.Name)
 		})
 		if !detected {
-			log.DebugDetailf("No secrets detected in env [%s]", env.Name)
+			log.Debugf("No secrets detected in env [%s]", env.Name)
 		}
 	}
 	return nil

--- a/pkg/kev/override.go
+++ b/pkg/kev/override.go
@@ -18,7 +18,6 @@ package kev
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/appvia/kev/pkg/kev/config"
 	composego "github.com/compose-spec/compose-go/types"
@@ -156,10 +155,10 @@ func (o *composeOverride) diff(other *composeOverride) changeset {
 }
 
 // patch patches an override based on the supplied changeset patches.
-func (o *composeOverride) patch(cset changeset, reporter io.Writer) {
-	cset.applyVersionPatchesIfAny(o, reporter)
-	cset.applyServicesPatchesIfAny(o, reporter)
-	cset.applyVolumesPatchesIfAny(o, reporter)
+func (o *composeOverride) patch(cset changeset) {
+	cset.applyVersionPatchesIfAny(o)
+	cset.applyServicesPatchesIfAny(o)
+	cset.applyVolumesPatchesIfAny(o)
 }
 
 // mergeInto merges an override onto a compose project.

--- a/pkg/kev/services.go
+++ b/pkg/kev/services.go
@@ -19,7 +19,6 @@ package kev
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"regexp"
 
 	"github.com/appvia/kev/pkg/kev/config"
@@ -69,7 +68,7 @@ func (s Services) Set() map[string]bool {
 	return out
 }
 
-func (s Services) detectSecrets(matchers []map[string]string, _ io.Writer, detectedFn func()) bool {
+func (s Services) detectSecrets(matchers []map[string]string, detectedFn func()) bool {
 	var matches []secretHit
 	for _, svc := range s {
 		matches = append(matches, svc.detectSecretsInEnvVars(matchers)...)

--- a/pkg/kev/testutil/testutil.go
+++ b/pkg/kev/testutil/testutil.go
@@ -14,30 +14,32 @@
  * limitations under the License.
  */
 
-package cmd
+package testutil
 
 import (
-	"os"
+	"bytes"
+	"strings"
 
-	"github.com/appvia/kev/pkg/kev"
-	"github.com/spf13/cobra"
+	"github.com/appvia/kev/pkg/kev/log"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 )
 
-func runDetectSecretsCmd(cmd *cobra.Command, _ []string) error {
-	cmdName := "Detect secrets"
-	verbose, _ := cmd.Root().Flags().GetBool("verbose")
+func NewLogger(level logrus.Level) *test.Hook {
+	var buffer = &bytes.Buffer{}
+	log.SetOutput(buffer)
+	log.SetLogLevel(logrus.DebugLevel)
+	return test.NewLocal(log.GetLogger())
+}
 
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return displayError(err)
+func GetLoggedMsgs(hook *test.Hook) string {
+	var out strings.Builder
+	for _, entry := range hook.Entries {
+		out.WriteString(entry.Message + "\n")
 	}
+	return out.String()
+}
 
-	setReporting(verbose)
-	displayCmdStarted(cmdName)
-
-	if err := kev.DetectSecrets(workingDir, nil); err != nil {
-		return displayError(err)
-	}
-
-	return nil
+func GetLoggedLevel(hook *test.Hook) string {
+	return hook.LastEntry().Level.String()
 }


### PR DESCRIPTION
Resolves #274 

- [x] Add `verbose` flag to the root command - similar to how `docker-compose` works.
- [x] Only display reconcile info when `verbose` flag is set.
- [x] Always warn on specific detected secret regardless of `verbose` flag.
- [x] Only display details of all secret detection (detected/non) when `verbose` flag is set.
- [x] Only display render logs when `verbose` flag is set.
- [x] Ensure how errors are displayed works with new log approach.
- [x] Fix tests and remove `reporter`.

To run in `verbose` mode:
- **init**: `kev -v init` or `kev --verbose init`.
- **render**: `kev -v render` or `kev --verbose render`.
