### PR TITLE
Fix dev mode

### DIFF
--- a/cmd/kev/cmd/detect.go
+++ b/cmd/kev/cmd/detect.go
@@ -39,5 +39,9 @@ func runDetectSecretsCmd(cmd *cobra.Command, _ []string) error {
 		return displayError(err)
 	}
 
+	if verbose {
+		os.Stdout.Write([]byte("\n"))
+	}
+
 	return nil
 }

--- a/cmd/kev/cmd/detect.go
+++ b/cmd/kev/cmd/detect.go
@@ -39,9 +39,7 @@ func runDetectSecretsCmd(cmd *cobra.Command, _ []string) error {
 		return displayError(err)
 	}
 
-	if verbose {
-		os.Stdout.Write([]byte("\n"))
-	}
+	os.Stdout.Write([]byte("\n"))
 
 	return nil
 }

--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -110,6 +110,10 @@ func runDevCmd(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
+			if err := runDetectSecretsCmd(cmd, args); err != nil {
+				return err
+			}
+
 			// re-render manifests for specified environments only
 			if err := runRenderCmd(cmd, args); err != nil {
 				return err

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -50,6 +50,10 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if verbose {
+		os.Stdout.Write([]byte("\n"))
+	}
+
 	return nil
 }
 

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -50,9 +50,7 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	if verbose {
-		os.Stdout.Write([]byte("\n"))
-	}
+	os.Stdout.Write([]byte("\n"))
 
 	return nil
 }

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -59,10 +59,11 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 
 func displayReconcileRules(verbose bool) {
 	if verbose {
-		_, _ = fmt.Fprintf(os.Stdout, "\033[2mHOW DOES RECONCILE WORK?\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\033[2m -- HOW DOES RECONCILE WORK? --\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ New services & volumes in a project will be added to all environments.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ Removed services & volumes from a project will be removed from all environments.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ Environment settings trump project settings, with the exception of ports.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ An environment can only override a service's Env Vars.\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\033[2m ------------------------------\n")
 	}
 }

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -109,5 +109,9 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if verbose {
+		os.Stdout.Write([]byte("\n"))
+	}
+
 	return nil
 }

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -109,9 +109,7 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if verbose {
-		os.Stdout.Write([]byte("\n"))
-	}
+	os.Stdout.Write([]byte("\n"))
 
 	return nil
 }

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -33,7 +33,7 @@ func setReporting(verbose bool) {
 }
 
 func displayCmdStarted(cmdName string) {
-	_, _ = os.Stdout.Write([]byte("᛬" + cmdName + " ...\n"))
+	_, _ = os.Stdout.Write([]byte("> " + cmdName + "...\n"))
 }
 
 func displayError(err error) error {

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -142,8 +142,8 @@ func Render(format string, singleFile bool, dir string, envs []string) error {
 func Watch(workDir string, envs []string, change chan<- string) error {
 	manifest, err := LoadManifest(workDir)
 	if err != nil {
-		log.Error("Unable to load app manifest")
-		return err
+		log.Errorf("Unable to load app manifest - %s", err)
+		os.Exit(1)
 	}
 
 	watcher, err := fsnotify.NewWatcher()


### PR DESCRIPTION
Resolves #282 

This PR:
- [x] Shows the reason when dev loop breaks
- [x] Exit "dev" mode entirely on config error
- [x] Minor visibility improvements when running dev command in verbose mode

"dev" mode should watch and notice config errors, communicate to the user and keep watching files - this will be addressed in the future PR.
