### PR TITLE
`dev` command shouldn't break on invalid config

### DIFF
--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/appvia/kev/pkg/kev"
@@ -161,7 +160,7 @@ func runDevCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof(`Running Kev in development mode... Watched environments: %s`, strings.Join(envs, ", "))
+	displayDevModeStarted(envs)
 
 	change := make(chan string, 50)
 	defer close(change)

--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -203,7 +203,7 @@ func runDevCmd(cmd *cobra.Command, args []string) error {
 			fmt.Printf("\n♻️  %s changed! Re-rendering manifests...\n\n", ch)
 
 			if err := runCommands(cmd, args); err != nil {
-				return displayError(err)
+				log.ErrorDetail(err)
 			}
 
 			// empty the buffer as we only ever do one re-render cycle per a batch of changes

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -36,6 +36,14 @@ func displayCmdStarted(cmdName string) {
 	_, _ = os.Stdout.Write([]byte("> " + cmdName + "...\n"))
 }
 
+func displayDevModeStarted(envs []string) {
+	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... listing environments:\n")
+	for _, env := range envs {
+		_, _ = fmt.Fprintf(os.Stdout, "\033[2m → "+env+"\n")
+	}
+	resetFormatting()
+}
+
 func displayError(err error) error {
 	log.ErrorDetail(err)
 	return err
@@ -56,4 +64,4 @@ func displayInitSuccess(w io.Writer, files []skippableFile) {
 	}
 }
 
-func resetFormatting() { fmt.Print(" \033[0m") }
+func resetFormatting() { fmt.Print(" \033[0m\n") }

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -37,7 +37,7 @@ func displayCmdStarted(cmdName string) {
 }
 
 func displayDevModeStarted(envs []string) {
-	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... listing environments:\n")
+	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... watched environments:\n")
 	for _, env := range envs {
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m → "+env+"\n")
 	}


### PR DESCRIPTION
Resolves #290 

- [x] Only log config errors - but don't stop.
- [x] Formatted dev mode starting banner.