### PR TITLE
Infer kev.service.type as ClusterIP

### DIFF
--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -634,13 +634,13 @@ The `service` group contains configuration detail around Kubernetes services and
 
 ## kev.service.type
 
-Defines the type of Kubernetes service for a specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/).
+Defines the type of Kubernetes service for a specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 
 Although Kev provides a variety of types you can use, it only tries to extract two types of services from the compose configuration, namely `None` or `ClusterIP`.
 
-If you need a different type, please configure it manually. The different types are listed and explained below. 
+If you need a different type, please configure it manually. The different types are listed and explained below. Related official K8s
 
-Here is the heuristic used to extract a `None` or `ClusterIP` type:
+Here is the heuristic used to extract a service type:
 
 * If compose project service publishes a port (i.e. defines a port mapping between host and container ports):
     * It will assume a `ClusterIP` service type
@@ -678,7 +678,7 @@ It is ideal for an internal service or locally testing an app before exposing it
 
 This service type is the most basic way to get external traffic directly to your service.
 
-Its opens a specific port on all the Nodes (the VMs), and any traffic that is sent to this port is forwarded to the service.
+Its opens a specific port on each of the K8s cluster Nodes, and any traffic that is sent to this port is forwarded to the ClusterIP service which is automatically created.
 
 You'll be able to contact the NodePort Service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`.
 
@@ -690,7 +690,7 @@ This is the same as a `ClusterIP` service type, but lacks load balancing or prox
 
 Specifically, it does have a service IP, but instead of load-balancing it will return the IPs of the associated Pods.
 
-It is ideal for scenarios like Pod to Pod communication.
+It is ideal for scenarios such as Pod to Pod communication or clustered applications node discovery.
 
 #### LoadBalancer
 

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -634,9 +634,13 @@ The `service` group contains configuration detail around Kubernetes services and
 
 ## kev.service.type
 
-Defines the type of Kubernetes service for a specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/). Kev will attempt to extract that information from the compose configuration.
+Defines the type of Kubernetes service for a specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/).
 
-The following heuristic determines the service type for application component:
+Although Kev provides a variety of types you can use, it only tries to extract two types of services from the compose configuration, namely `None` or `ClusterIP`.
+
+If you need a different type, please configure it manually. The different types are listed and explained below. 
+
+Here is the heuristic used to extract a `None` or `ClusterIP` type:
 
 * If compose project service publishes a port (i.e. defines a port mapping between host and container ports):
     * It will assume a `ClusterIP` service type

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -634,18 +634,20 @@ The `service` group contains configuration detail around Kubernetes services and
 
 ## kev.service.type
 
-Defines type of Kubernetes service for specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/). Kev will attempt to extract that information from the compose configuration.
+Defines the type of Kubernetes service for a specific workload. See official K8s [documentation](https://kubernetes.io/docs/concepts/services-networking/service/). Kev will attempt to extract that information from the compose configuration.
 
-The following heuristic is used to determine service type for application component:
+The following heuristic determines the service type for application component:
 
 * If compose project service publishes a port (i.e. defines a port mapping between host and container ports):
-    * It will assume `ClusterIP` service type
+    * It will assume a `ClusterIP` service type
 * If compose project service does not publish a port:
-    * It will assume `None` service type
+    * It will assume a `None` service type
 
 ### Default: `None` - no service will be created for the workload by default!
 
-### Possible options: `None`, `Headless`, `ClusterIP`, `Nodeport`, `LoadBalancer`.
+### Possible options: `None`, `ClusterIP`, `Nodeport`, `Headless`,  `LoadBalancer`.
+
+These options are useful for exposing a Service either internally or externally onto an external IP address, that's outside of your cluster.
 
 > kev.service.type:
 ```yaml
@@ -656,8 +658,46 @@ services:
       kev.service.type: LoadBalancer
 ...
 ```
-
 #### None
+
+Simply, no service will be created.
+
+#### ClusterIP
+
+Choosing this type makes the Service only reachable internally from within the cluster by other services. There is no external access.
+
+In development, you can access this service on your localhost using [Port Forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/).
+
+It is ideal for an internal service or locally testing an app before exposing it externally.
+
+#### Nodeport
+
+This service type is the most basic way to get external traffic directly to your service.
+
+Its opens a specific port on all the Nodes (the VMs), and any traffic that is sent to this port is forwarded to the service.
+
+You'll be able to contact the NodePort Service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`.
+
+It is ideal for running a service with limited availability, e.g. a demo app.
+
+#### Headless
+
+This is the same as a `ClusterIP` service type, but lacks load balancing or proxying. Allowing you to connect to a Pod directly.
+
+Specifically, it does have a service IP, but instead of load-balancing it will return the IPs of the associated Pods.
+
+It is ideal for scenarios like Pod to Pod communication.
+
+#### LoadBalancer
+
+This service type is the standard way to expose a service to the internet.
+
+All traffic on the port you specify will be forwarded to the service allowing any kind of traffic to it, e.g. HTTP, TCP, UDP, Websockets, gRPC, etc...
+
+Again, it is ideal for exposing a service or app to the internet under a single IP address.
+
+Practically, in non development environments, a LoadBalancer will be used to route traffic to an Ingress to expose multiple services under the same IP address and keep your costs down.     
+
 
 ## kev.service.nodeport.port
 

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -639,14 +639,9 @@ Defines type of Kubernetes service for specific workload. See official K8s [docu
 The following heuristic is used to determine service type for application component:
 
 * If compose project service publishes a port (i.e. defines a port mapping between host and container ports):
-    * and specifies a mode as `host`
-        * It will assume `NodePort` service type
-    * and specifies a mode as `ingress`
-        * It will assume `LoadBalancer` service type
-    * and doesn't specify port mode
-        * It will assume `ClusterIP` service type
-* If compose service doesn't publish a port but defines container port.
-    * It will assume `Headless` service type
+    * It will assume `ClusterIP` service type
+* If compose project service does not publish a port:
+    * It will assume `None` service type
 
 ### Default: `None` - no service will be created for the workload by default!
 
@@ -661,6 +656,8 @@ services:
       kev.service.type: LoadBalancer
 ...
 ```
+
+#### None
 
 ## kev.service.nodeport.port
 
@@ -684,7 +681,7 @@ services:
 
 ## kev.service.expose
 
-Defines whether to expose the service to external world. This detail can't be easily derived from the compose file and so in order to expose a service to external workld user must explicitly instruct Kev to do so. By default all component services aren't exposed i.e. have no ingress attached to them.
+Defines whether to expose the service to external world. This detail can't be easily derived from the compose file and so in order to expose a service to external world user must explicitly instruct Kev to do so. By default all component services aren't exposed i.e. have no ingress attached to them.
 
 ### Default: `""` - No ingress will be created!
 

--- a/docs/tutorials/getting-started-with-kev.md
+++ b/docs/tutorials/getting-started-with-kev.md
@@ -123,7 +123,7 @@ environments:
 
 The created `local` and `stage` _Compose environment overrides_ are currently identical.
 
-The `labels` section for each service enable you to control how the app runs on Kubernetes. See the [configuration reference](../reference/config-params.md) to understand how these affect deployments.
+The `labels` section for each service enables you to control how the app runs on Kubernetes. See the [configuration reference](../reference/config-params.md) to find all the available options and understand how they affect deployments.
 
 We'll be adjusting these values soon per target environment. For now, they look as below,
 
@@ -132,22 +132,8 @@ version: "3.7"
 services:
   wordpress:
     labels:
-      kev.service.type: LoadBalancer
-      kev.workload.image-pull-policy: IfNotPresent
       kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service wordpress"]'
-      kev.workload.liveness-probe-disabled: "false"
-      kev.workload.liveness-probe-initial-delay: 1m0s
-      kev.workload.liveness-probe-interval: 1m0s
-      kev.workload.liveness-probe-retries: "3"
-      kev.workload.liveness-probe-timeout: 10s
-      kev.workload.max-cpu: "0.5"
-      kev.workload.cpu: "0.1"
-      kev.workload.max-memory: 500Mi
-      kev.workload.memory: 10Mi
       kev.workload.replicas: "1"
-      kev.workload.rolling-update-max-surge: "1"
-      kev.workload.service-account-name: default
-      kev.workload.type: Deployment
 ```
 
 ## Moving to Kubernetes
@@ -430,10 +416,7 @@ services:
   wordpress:
     labels:
       ...
-      ...
       kev.workload.replicas: "5"
-      ...
-      ...
 ```
 
 ### Re-sync Kubernetes

--- a/e2e/wordpress-mysql/wordpress-mysql.bats
+++ b/e2e/wordpress-mysql/wordpress-mysql.bats
@@ -50,7 +50,7 @@ load ../helper
   echo $output
   [ "$status" -eq 0 ]
 
-  run ensure-service-type "$E2E_NS" "io.kev.service=wordpress" "loadbalancer"
+  run ensure-service-type "$E2E_NS" "io.kev.service=wordpress" "clusterip"
   echo $output
   [ "$status" -eq 0 ]
 

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -176,7 +176,6 @@ func (e *Environment) patch(cset changeset) {
 
 func (e *Environment) prepareForMergeUsing(override *composeOverride) {
 	e.override = e.override.expandLabelsFrom(override)
-	e.override.overrideServiceTypeFrom(override)
 }
 
 func (e *Environment) mergeInto(p *ComposeProject) error {

--- a/pkg/kev/extract.go
+++ b/pkg/kev/extract.go
@@ -82,19 +82,7 @@ func extractServiceTypeLabels(source composego.ServiceConfig, target *ServiceCon
 	if source.Ports == nil {
 		target.Labels.Add(config.LabelServiceType, config.NoService)
 	} else {
-		for _, p := range source.Ports {
-			if p.Published != 0 && p.Mode == "host" {
-				target.Labels.Add(config.LabelServiceType, config.NodePortService)
-			} else if p.Published != 0 && p.Mode == "ingress" {
-				target.Labels.Add(config.LabelServiceType, config.LoadBalancerService)
-			} else if p.Published != 0 || (p.Published == 0 && p.Target != 0) {
-				target.Labels.Add(config.LabelServiceType, config.ClusterIPService)
-			} else if p.Published == 0 {
-				target.Labels.Add(config.LabelServiceType, config.HeadlessService)
-			}
-			// @todo: Processing just the first port for now!
-			break
-		}
+		target.Labels.Add(config.LabelServiceType, config.ClusterIPService)
 	}
 }
 

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Reconcile", func() {
 
 				It("should update the label in all environments", func() {
 					s, _ := env.GetService("wordpress")
-					Expect(s.Labels["kev.service.type"]).To(Equal("NodePort"))
+					Expect(s.Labels["kev.service.type"]).To(Equal("ClusterIP"))
 				})
 
 				It("should log the change summary using the debug level", func() {
@@ -199,7 +199,7 @@ var _ = Describe("Reconcile", func() {
 					Expect(loggedMsgs).To(ContainSubstring("updated"))
 					Expect(loggedMsgs).To(ContainSubstring(config.LabelServiceType))
 					Expect(loggedMsgs).To(ContainSubstring("LoadBalancer"))
-					Expect(loggedMsgs).To(ContainSubstring("NodePort"))
+					Expect(loggedMsgs).To(ContainSubstring("ClusterIP"))
 				})
 
 				It("should not error", func() {

--- a/pkg/kev/override.go
+++ b/pkg/kev/override.go
@@ -136,19 +136,6 @@ func (o *composeOverride) volumesLabelsExpandedFrom(other *composeOverride) Volu
 	return out
 }
 
-func (o *composeOverride) overrideServiceTypeFrom(other *composeOverride) {
-	var services Services
-	for _, otherSvc := range other.Services {
-		dstSvc, err := o.getService(otherSvc.Name)
-		if err != nil {
-			continue
-		}
-		dstSvc.Labels[config.LabelServiceType] = otherSvc.Labels[config.LabelServiceType]
-		services = append(services, dstSvc)
-	}
-	o.Services = services
-}
-
 // diff detects changes between an override against another override.
 func (o *composeOverride) diff(other *composeOverride) changeset {
 	return newChangeset(other, o)

--- a/pkg/kev/testdata/reconcile-service-edit/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-edit/docker-compose.kev.dev.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   db:
     labels:
-      kev.service.type: None
+      kev.service.type: ClusterIP
       kev.workload.cpu: "0.1"
       kev.workload.image-pull-policy: IfNotPresent
       kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service db"]'

--- a/pkg/kev/testdata/reconcile-service-edit/docker-compose.yaml
+++ b/pkg/kev/testdata/reconcile-service-edit/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
       - MYSQL_DATABASE=wordpress
       - MYSQL_USER=wordpress
       - MYSQL_PASSWORD=wordpress
+    ports:
+      - "3306"
+
   wordpress:
     image: wordpress:latest
     ports:


### PR DESCRIPTION
Resolves #308 

- [x] Ensures any service with a port configured is mapped to `kev.service.type`:`ClusterIP`
- [x] Updates e2e tests to match new reality.
- [x] Removes redundant code.
- [x] Docs and reference updated.