### PR TITLE
kev dev: reconciles and renders updated environments.

### DIFF
--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -80,6 +80,9 @@ func init() {
 		"Override default Kubernetes manifests output directory. Default: k8s/<env>",
 	)
 
+	flags.StringSlice("environment", []string{}, "")
+	_ = flags.MarkHidden("environment")
+
 	flags.BoolP("skaffold", "", false, "[Experimental] Activates Skaffold dev loop.")
 
 	flags.StringP(
@@ -215,7 +218,6 @@ func runCommands(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// re-render manifests for specified environments only
 	if err := runRenderCmd(cmd, args); err != nil {
 		return err
 	}

--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -29,11 +29,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var devLongDesc = `(dev) Continuously reconciles changes from all source compose files and re-renders K8s manifests.
+var devLongDesc = `(dev) Watches to reconcile changes from source compose files and environments then re-renders K8s manifests.
 
 Examples:
 
-   ### Run Kev in dev mode against all environments
+   ### Run Kev in dev mode
    $ kev dev
 
    ### Use a custom directory to render manifests 
@@ -45,7 +45,7 @@ Examples:
 
 var devCmd = &cobra.Command{
 	Use:   "dev",
-	Short: "Watches changes to the source Compose files and re-renders K8s manifests.",
+	Short: "Watches to reconcile changes from source compose files and environments then re-renders K8s manifests.",
 	Long:  devLongDesc,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifySkaffoldExpectedFlags(cmd)

--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var devLongDesc = `(dev) Watches to reconcile changes from source compose files and environments then re-renders K8s manifests.
+var devLongDesc = `(dev) Continuous reconcile and re-render of K8s manifests with optional project build, push and deploy (using --skaffold).
 
 Examples:
 
@@ -45,7 +45,7 @@ Examples:
 
 var devCmd = &cobra.Command{
 	Use:   "dev",
-	Short: "Watches to reconcile changes from source compose files and environments then re-renders K8s manifests.",
+	Short: "Continuous reconcile and re-render of K8s manifests with optional project build, push and deploy (using --skaffold).",
 	Long:  devLongDesc,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return verifySkaffoldExpectedFlags(cmd)

--- a/cmd/kev/cmd/reconcile.go
+++ b/cmd/kev/cmd/reconcile.go
@@ -58,10 +58,10 @@ func runReconcileCmd(cmd *cobra.Command, _ []string) error {
 func displayReconcileRules(verbose bool) {
 	if verbose {
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m -- HOW DOES RECONCILE WORK? --\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ Environment settings always override project settings.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ New services & volumes in a project will be added to all environments.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ Removed services & volumes from a project will be removed from all environments.\n")
-		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ Environment settings trump project settings, with the exception of ports.\n")
-		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ An environment can only override a service's Env Vars.\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\033[2m᛫ A service's Env Vars can be overridden by an environment.\n")
 		_, _ = fmt.Fprintf(os.Stdout, "\033[2m ------------------------------\n")
 	}
 }

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -37,7 +37,7 @@ func displayCmdStarted(cmdName string) {
 }
 
 func displayDevModeStarted() {
-	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... watched all environments\n")
+	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... watching for changes\n")
 	resetFormatting()
 }
 
@@ -61,4 +61,4 @@ func displayInitSuccess(w io.Writer, files []skippableFile) {
 	}
 }
 
-func resetFormatting() { fmt.Print(" \033[0m") }
+func resetFormatting() { fmt.Print(" \033[0m\n") }

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -36,11 +36,8 @@ func displayCmdStarted(cmdName string) {
 	_, _ = os.Stdout.Write([]byte("> " + cmdName + "...\n"))
 }
 
-func displayDevModeStarted(envs []string) {
-	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... watched environments:\n")
-	for _, env := range envs {
-		_, _ = fmt.Fprintf(os.Stdout, "\033[2m → "+env+"\n")
-	}
+func displayDevModeStarted() {
+	_, _ = fmt.Fprintf(os.Stdout, "\033[2m[development mode] ... watched all environments\n")
 	resetFormatting()
 }
 
@@ -64,4 +61,4 @@ func displayInitSuccess(w io.Writer, files []skippableFile) {
 	}
 }
 
-func resetFormatting() { fmt.Print(" \033[0m\n") }
+func resetFormatting() { fmt.Print(" \033[0m") }

--- a/docs/tutorials/kev-dev-with-skaffold.md
+++ b/docs/tutorials/kev-dev-with-skaffold.md
@@ -18,12 +18,12 @@ However, when frequent changes are made to any of the source or environment spec
 
 To automate the process of rendering K8s manifests, run Kev in development mode (see command [reference](cli/kev_dev.md) for details)
 
-> Run Kev in dev mode: starts the watch loop and automatically re-renders K8s manifests for affected environments.
+> Run Kev in dev mode: starts the watch loop and automatically re-renders K8s manifests for changed environments.
 ```sh
 kev dev
 ````
 
-It will start the watch loop over source compose & environment override files. When a modification is detected it automatically re-renders Kubernetes manifests for the affected environments.
+It will start the watch loop over source compose & environment override files. When a modification is detected it automatically re-renders Kubernetes manifests for the changed environments.
 
 ## Automatic Develop / Build / Push / Deploy
 

--- a/docs/tutorials/kev-dev-with-skaffold.md
+++ b/docs/tutorials/kev-dev-with-skaffold.md
@@ -5,7 +5,7 @@ title: Kev dev with skaffold
 
 # Kev Dev w/Skaffold
 
-This tutorial will walk you through how to iterate on a Kubernetes application using the _Kev_ `dev` command with an optional [Skaffold](https://skaffold.dev/) hook.
+This tutorial will walk you through how to iterate on a Kubernetes application using the Kev `dev` command with an optional [Skaffold](https://skaffold.dev/) hook.
 
 We encourage everyone to get familiar with the [Getting started with Kev](getting-started-with-kev.md) tutorial before proceeding with this guide.
 
@@ -16,22 +16,18 @@ with a simple `kev render` command.
 
 However, when frequent changes are made to any of the source or environment specific compose files, this becomes cumbersome.
 
-To automate the process of rendering K8s manifests, run _Kev_ in development mode (see command [reference](cli/kev_dev.md) for details)
+To automate the process of rendering K8s manifests, run Kev in development mode (see command [reference](cli/kev_dev.md) for details)
 
-> Run Kev in dev mode. Starts the watch loop and automatically re-renders K8s manifests.
+> Run Kev in dev mode: starts the watch loop and automatically re-renders K8s manifests for affected environments.
 ```sh
-# for all environments
 kev dev
-
-# for specified environment(s)
-kev dev -e myenv
 ````
 
-It will start the watch loop over source compose & environment override files. When a modification is detected it automatically re-renders Kubernetes manifests for environments specified via `--environment | -e` flag(s). If no environments have been specified it defaults to `dev` environment.
+It will start the watch loop over source compose & environment override files. When a modification is detected it automatically re-renders Kubernetes manifests for the affected environments.
 
 ## Automatic Develop / Build / Push / Deploy
 
-This section will describe how to take advantage of existing Development Lifecycle tools enhancing developer experience when iterating on the Kubernetes application locally. We'll focus on _Kev_'s [Skaffold](https://skaffold.dev/) integration.
+This section will describe how to take advantage of existing Development Lifecycle tools enhancing developer experience when iterating on the Kubernetes application locally. We'll focus on Kev's [Skaffold](https://skaffold.dev/) integration.
 
 ## ⚬ Initialise Kev project with Skaffold support
 
@@ -48,7 +44,7 @@ This command prepares your application and bootstraps a new Skaffold config (_sk
 
 If a Kev project has been previously initialised without Skaffold support, the easiest way forward to adopt Skaffold is to remove _kev.yaml_ file and initialize the project again.
 
-**Note:** Be mindful that names of all the environments you want to track must be specified - _Kev_ `init` won't automatically discover existing environment override files!
+**Note:** Be mindful that names of all the environments you want to track must be specified - Kev `init` won't automatically discover existing environment override files!
 
 Alternatively, use `skaffold init` to bootstrap _skaffold.yaml_ and tell Kev about the fact by adding the following line in _kev.yaml_ file:
 
@@ -71,7 +67,7 @@ skaffold: skaffold.yaml # <= tell Kev that skaffold is now initialised
 
 ## ⚬ Kev + Skaffold
 
-At this point all you need to do to take advantage of Skaffold integration is to start _Kev_ in [development](cli/kev_dev.md) mode with Skaffold hook enabled:
+At this point all you need to do to take advantage of Skaffold integration is to start Kev in [development](cli/kev_dev.md) mode with Skaffold hook enabled:
 
 > Start Kev in development with Skaffold integration activated
 ```sh

--- a/docs/tutorials/simple-nodejs-app-workflow.md
+++ b/docs/tutorials/simple-nodejs-app-workflow.md
@@ -49,7 +49,7 @@ Inspect produced Kubernetes manifests at default `k8s` directory.
 
 ### Watch for Compose changes and auto-rebuild K8s manifests
 
-Run the command below to continuously watch for changes made to any of the source / environment Compose files related to your application and automatically rebuild Kubernetes manifests for affected environments.
+Run the command below to continuously watch for changes made to any of the source / environment Compose files related to your application and automatically rebuild Kubernetes manifests for changed environments.
 
 See [help](../../docs/cli/kev_dev.md) for usage examples.
 

--- a/docs/tutorials/simple-nodejs-app-workflow.md
+++ b/docs/tutorials/simple-nodejs-app-workflow.md
@@ -49,7 +49,9 @@ Inspect produced Kubernetes manifests at default `k8s` directory.
 
 ### Watch for Compose changes and auto-rebuild K8s manifests
 
-Run the command below to continously watch for changes made to any of the source / environment Compose files related to your application and automatically rebuild Kubernetes manifests for all environments. See [help](../../docs/cli/kev_dev.md) for usage examples.
+Run the command below to continuously watch for changes made to any of the source / environment Compose files related to your application and automatically rebuild Kubernetes manifests for affected environments.
+
+See [help](../../docs/cli/kev_dev.md) for usage examples.
 
 > Watch Compose changes and auto render Kubernetes manifests:
 ```sh
@@ -58,7 +60,9 @@ kev dev
 
 ### Watch for Compose and Application source code changes with Build/Push/Deploy loop enabled
 
-Watch for the changes to your application Compose files, as well as application source code and automatically rebuild the K8s manifests and Build/Push/Deploy the app (via Skaffold dev loop) to any Kubernetes cluster upon detected changes. See [help](../../docs/cli/kev_dev.md) for usage examples.
+Watch for changes to your application's Compose files plus project source code. Then, automatically rebuild the K8s manifests and build/push/deploy the app via Skaffold dev loop to any Kubernetes cluster upon detected changes.
+
+See [help](../../docs/cli/kev_dev.md) for usage examples.
 
 > Watch Compose and App source code changes, render manifests and build/push/deploy with Skaffold:
 ```sh
@@ -70,9 +74,9 @@ Open the browser at `http://localhost:8080`. You should see `Hello World` displa
 
 *NOTE*: The command above will use current kubectl context, and will attempt to deploy your app to `default` namespace. Those can be adjusted with `--kubecontext=<context>` & `--namespace=<ns>` options added to the command above.
 
-*IMPORTANT*: If `--kubecontext` is pointing at remote Kubernetes cluster you need to make sure that you adjust `image` in docker-compose.yaml file so that it points at registry you control and are able to push to. Should that be a private registry then make sure that the remote Kubernetes cluster is able to [pull images from it](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+**IMPORTANT**: If `--kubecontext` is pointing at remote Kubernetes cluster you need to make sure you adjust the `image` in docker-compose.yaml file so that it points at registry you control and are able to push to. Should that be a private registry then make sure that the remote Kubernetes cluster is able to [pull images from it](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 
-Once the app has been built, pushed and deployed via _Kev's_ Skaffold integration you may inspect that the Node app is running in your cluster:
+Once the app has been built, pushed and deployed via Kev's Skaffold integration you may inspect that the Node app is running in your cluster:
 
 > List Kubernetes application pods for the Node.js app:
 ```sh

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -129,7 +129,6 @@ func Watch(workDir string, change chan<- string) error {
 	}()
 
 	files := manifest.GetSourcesFiles()
-	// filteredEnvs, err := manifest.GetEnvironments(envs)
 	filteredEnvs, err := manifest.GetEnvironments([]string{})
 	for _, e := range filteredEnvs {
 		files = append(files, e.File)

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -69,8 +69,13 @@ func DetectSecrets(workingDir string) error {
 	if err != nil {
 		return err
 	}
-	m.DetectSecretsInSources(config.SecretMatchers)
-	m.DetectSecretsInEnvs(config.SecretMatchers)
+
+	if err := m.DetectSecretsInSources(config.SecretMatchers); err != nil {
+		return err
+	}
+	if err := m.DetectSecretsInEnvs(config.SecretMatchers); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -86,7 +91,7 @@ func Render(workingDir string, format string, singleFile bool, dir string, envs 
 }
 
 // Watch continuously watches source compose files & environment overrides and notifies changes to a channel
-func Watch(workDir string, envs []string, change chan<- string) error {
+func Watch(workDir string, change chan<- string) error {
 	manifest, err := LoadManifest(workDir)
 	if err != nil {
 		log.Errorf("Unable to load app manifest - %s", err)
@@ -124,7 +129,8 @@ func Watch(workDir string, envs []string, change chan<- string) error {
 	}()
 
 	files := manifest.GetSourcesFiles()
-	filteredEnvs, err := manifest.GetEnvironments(envs)
+	// filteredEnvs, err := manifest.GetEnvironments(envs)
+	filteredEnvs, err := manifest.GetEnvironments([]string{})
 	for _, e := range filteredEnvs {
 		files = append(files, e.File)
 	}
@@ -143,8 +149,8 @@ func Watch(workDir string, envs []string, change chan<- string) error {
 
 // ActivateSkaffoldDevLoop checks whether skaffold dev loop can be activated, and returns an error if not.
 // It'll also attempt to reconcile Skaffold profiles before starting dev loop - this is done
-// so that necessary profiles are added to the skaffold config. It's necessary as environment
-// specific profile is supplied to skaffold so it knows what manifests to deploy and to which k8s cluster.
+// so that necessary profiles are added to the Skaffold config. It's necessary as environment
+// specific profile is supplied to Skaffold so it knows what manifests to deploy and to which k8s cluster.
 func ActivateSkaffoldDevLoop(workDir string) (string, *SkaffoldManifest, error) {
 	manifest, err := LoadManifest(workDir)
 	if err != nil {


### PR DESCRIPTION
Resolves #319 

- [x] Removed environments param where it is no longer needed.
- [x] Kept `environment` flag as [hidden](https://pkg.go.dev/github.com/spf13/pflag#FlagSet.MarkHidden) as it is till required by the `render` cmd.
- [x] Updated `dev` cmd descriptions.
- [x] Updated docs.