### PR TITLE
kev dev with skaffold: by default deploys to sandbox dev environment.

### DIFF
--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -102,8 +102,8 @@ func init() {
 	flags.StringP(
 		"kev-env",
 		"",
-		"", // default: it'll use the first element from `environment` slice...
-		"[Experimental] Kev environment that will be deployed by Skaffold. If not specified it'll use the first env name passed in '--environment' flag.",
+		kev.SandboxEnv,
+		fmt.Sprintf("[Experimental] Kev environment that will be deployed by Skaffold. If not specified it'll use the sandbox %s env.", kev.SandboxEnv),
 	)
 
 	rootCmd.AddCommand(devCmd)
@@ -119,7 +119,7 @@ func verifySkaffoldExpectedFlags(cmd *cobra.Command) error {
 	if skaffold {
 		if len(namespace) == 0 {
 			log.Warnf("Skaffold `namespace` not specified - will use `%s`", skaffoldNamespace)
-			cmd.Flag("namespace").Value.Set(skaffoldNamespace)
+			_ = cmd.Flag("namespace").Value.Set(skaffoldNamespace)
 		} else {
 			log.Infof("Skaffold dev loop will deploy to `%s` namespace", namespace)
 		}
@@ -131,8 +131,7 @@ func verifySkaffoldExpectedFlags(cmd *cobra.Command) error {
 		}
 
 		if len(kevenv) == 0 {
-			log.Warnf("Skaffold will use profile pointing at default `%s` environment. You may override it with `--kev-dev` flag.", "dev")
-			cmd.Flag("kev-env").Value.Set("dev")
+			log.Warnf("Skaffold will use profile pointing at the sandbox `%s` environment. You may override it with `--kev-env` flag.", kev.SandboxEnv)
 		} else {
 			log.Infof("Skaffold will use profile pointing at Kev `%s` environment", kevenv)
 		}

--- a/cmd/kev/cmd/init.go
+++ b/cmd/kev/cmd/init.go
@@ -138,7 +138,7 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 			return displayError(err)
 		}
 
-		if err := createOrUpdateSkaffoldManifest(skaffoldManifestPath, envs, project, &results); err != nil {
+		if err := createOrUpdateSkaffoldManifest(skaffoldManifestPath, manifest.GetEnvironmentsNames(), project, &results); err != nil {
 			return displayError(err)
 		}
 	}
@@ -174,9 +174,9 @@ func writeTo(filePath string, w io.WriterTo) error {
 
 func createOrUpdateSkaffoldManifest(path string, envs []string, project *kev.ComposeProject, results *[]skippableFile) error {
 	if manifestExistsForPath(path) {
-		// skaffold manifest already present - add additional profiles to it!
+		// Skaffold manifest already present - add additional profiles to it!
 		// Note: kev will skip profiles with names matching those of existing
-		// profile names defined in skaffold to avoid profile "hijack".
+		// profile names defined in Skaffold to avoid profile "hijack".
 
 		updatedSkaffold, err := kev.AddProfiles(path, envs, true)
 		if err != nil {

--- a/docs/tutorials/kev-dev-with-skaffold.md
+++ b/docs/tutorials/kev-dev-with-skaffold.md
@@ -35,7 +35,7 @@ In order to take advantage of Skaffold, you must prepare your project accordingl
 
 > Initialise Kev project with Skaffold support
 ```sh
-kev init --skaffold -e dev -e ...
+kev init --skaffold -e stage 
 ```
 
 This command prepares your application and bootstraps a new Skaffold config (_skaffold.yaml_) if it doesn't already exist. Alternatively, it'll add environment & helper profiles to already existing Skaffold config automatically. The profiles added by Kev can be used to control which application Kubernetes manifests should be deployed and to which K8s cluster, be it local or remote. They should also come handy when defining steps in CI/CD pipelines.
@@ -80,7 +80,7 @@ kev dev --skaffold
 ```
 
 The command will start two watch loops,
-1) one responsible for reconciling changes in your Docker Compose project source and environment override files to produce up-to-date Kubernetes manifests for each of specified environments (or default `dev` environment if none provided),
+1) one responsible for reconciling changes in your Docker Compose project source and environment override files to produce up-to-date Kubernetes manifests for changed environments,
 2) a second loop responsible for watching changes in your project source code and deployment manifests.
 
 Every change made to the Docker Compose project will produce an updated set of K8s manifests for your app, which in turn will inform Skaffold to trigger another Build/Push/Deploy iteration. This will deploy a fresh set of manifests to the target Kuberentes cluster.
@@ -89,7 +89,7 @@ There are a few extra bits of information that Skaffold requires to perform its 
 
 * `--namespace | -n` - Informs Skaffold which namespace the application should be deployed to. Default: `default`.
 * `--kubecontext | -k` - Specified kubectl context to be used by Skaffold. This determines the cluster to which your application will be deployed to. If not specified it will default to current [kebectl context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration).
-* `--kev-env` - Kev tracked environment name of which Kubernetes manifests will be deployed to a target cluster/namespace. Defaults to the first specified environment passed via `--environment (-e)` flag. If no environments have been specified it will default to `dev` environment.
+* `--kev-env` - Kev tracked environment name of which Kubernetes manifests will be deployed to a target cluster/namespace. Defaults to the sandbox `dev` environment, if no environments have been specified.
 
 When the dev loop is interrupted with Ctrl+C it will automatically cleanup all deployed K8s objects from a target namespace and attempt to prune locally built docker images.
 

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -30,7 +30,7 @@ import (
 const (
 	// ManifestName main application manifest
 	ManifestName = "kev.yaml"
-	sandboxEnv   = "dev"
+	SandboxEnv   = "dev"
 )
 
 // Init initialises a kev manifest including source compose files and environments.

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -115,8 +115,8 @@ func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 	fileNameTemplate := m.GetEnvironmentFileNameTemplate()
 
 	m.Environments = Environments{}
-	if !contains(candidates, sandboxEnv) {
-		candidates = append(candidates, sandboxEnv)
+	if !contains(candidates, SandboxEnv) {
+		candidates = append(candidates, SandboxEnv)
 	}
 
 	override := m.getSourcesOverride().toBaseLabels()

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -202,7 +202,7 @@ func BaseSkaffoldManifest() *SkaffoldManifest {
 func (s *SkaffoldManifest) SetProfiles(envs []string) {
 
 	if len(envs) == 0 {
-		envs = []string{sandboxEnv}
+		envs = []string{SandboxEnv}
 	}
 
 	for _, e := range envs {


### PR DESCRIPTION
Resolves #318 

- [x] Init with `--skaffold` creates profiles for minted environments (including sandbox `dev` env).
- [x] `kev-env` uses sandbox `dev` environment by default.
- [x] Updated docs.