### PR TITLE
Kev.yaml Id field is missing

### DIFF
--- a/pkg/kev/kev_init_test.go
+++ b/pkg/kev/kev_init_test.go
@@ -17,6 +17,8 @@
 package kev_test
 
 import (
+	"bytes"
+
 	"github.com/appvia/kev/pkg/kev"
 	"github.com/appvia/kev/pkg/kev/config"
 	. "github.com/onsi/ginkgo"
@@ -37,6 +39,30 @@ var _ = Describe("Init", func() {
 		if mErr == nil {
 			env, _ = manifest.GetEnvironment("dev")
 		}
+	})
+
+	Context("manifest", func() {
+		BeforeEach(func() {
+			workingDir = "./testdata/init-default/compose-yml"
+		})
+
+		It("should contain an id attribute", func() {
+			Expect(manifest.Id).ToNot(BeEmpty())
+		})
+
+		Context("marshalling", func() {
+			It("should write out a yaml file with manifest data", func() {
+				var actual bytes.Buffer
+				_, err := manifest.WriteTo(&actual)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actual.String()).To(MatchRegexp(`id: [a-z0-9]+`))
+				Expect(actual.String()).To(ContainSubstring("compose:"))
+				Expect(actual.String()).To(MatchRegexp(`.*- .*compose.yml`))
+				Expect(actual.String()).To(ContainSubstring("environments:"))
+				Expect(actual.String()).To(MatchRegexp(`dev: .*compose.kev.dev.yml`))
+			})
+		})
 	})
 
 	Context("with no alternate compose files supplied", func() {

--- a/pkg/kev/kev_test.go
+++ b/pkg/kev/kev_test.go
@@ -26,29 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func TestManifestMarshalsCorrectly(t *testing.T) {
-	files := []string{"testdata/in-cluster-wordpress/docker-compose.yaml"}
-	manifest, err := kev.Init(files, []string{}, "")
-	if err != nil {
-		t.Fatalf("Unexpected error:\n%s", err)
-	}
-
-	var actual bytes.Buffer
-	if _, err := manifest.WriteTo(&actual); err != nil {
-		t.Fatalf("Unexpected error:\n%s", err)
-	}
-
-	expected, err := ioutil.ReadFile("testdata/in-cluster-wordpress/kev.yaml")
-	if err != nil {
-		t.Fatalf("Unexpected error:\n%s", err)
-	}
-
-	diff := cmp.Diff(expected, actual.Bytes())
-	if diff != "" {
-		t.Fatalf("actual does not match expected\n%s", diff)
-	}
-}
-
 func TestInitProvidesEnvironmentConfig(t *testing.T) {
 	files := []string{"testdata/in-cluster-wordpress/docker-compose.yaml"}
 	manifest, err := kev.Init(files, []string{}, "")
@@ -78,6 +55,7 @@ func TestInitProvidesEnvironmentConfig(t *testing.T) {
 
 func TestCanLoadAManifest(t *testing.T) {
 	expected := &kev.Manifest{
+		Id: "random-uuid",
 		Sources: &kev.Sources{
 			Files: []string{
 				"testdata/in-cluster-wordpress/docker-compose.yaml",
@@ -96,6 +74,7 @@ func TestCanLoadAManifest(t *testing.T) {
 		t.Fatalf("Unexpected error:\n%s", err)
 	}
 
+	expected.Id = actual.Id
 	diff := cmp.Diff(expected, actual, cmpopts.IgnoreUnexported(kev.Sources{}, kev.Environment{}))
 	if diff != "" {
 		t.Fatalf("actual does not match expected:\n%s", diff)

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -27,6 +27,7 @@ import (
 	"github.com/appvia/kev/pkg/kev/converter"
 	"github.com/appvia/kev/pkg/kev/log"
 	composego "github.com/compose-spec/compose-go/types"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -37,7 +38,10 @@ func NewManifest(files []string, workingDir string) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Manifest{Sources: s}, nil
+	return &Manifest{
+		Id:      uuid.New().String(),
+		Sources: s,
+	}, nil
 }
 
 // LoadManifest returns application manifests.

--- a/pkg/kev/testdata/detect-secrets/kev.yaml
+++ b/pkg/kev/testdata/detect-secrets/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/detect-secrets/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/in-cluster-wordpress/kev.yaml
+++ b/pkg/kev/testdata/in-cluster-wordpress/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/in-cluster-wordpress/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/merge/kev.yaml
+++ b/pkg/kev/testdata/merge/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/merge/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-env-var-override/kev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-override/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-env-var-override/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-env-var-removal/kev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-removal/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-env-var-removal/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/kev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-env-var-unassigned/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-override-keep/kev.yaml
+++ b/pkg/kev/testdata/reconcile-override-keep/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-override-keep/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-override-rollback/kev.yaml
+++ b/pkg/kev/testdata/reconcile-override-rollback/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-override-rollback/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-service-basic/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-service-basic/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-service-deploy/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-deploy/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-service-deploy/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-service-edit/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-edit/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-service-edit/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-service-healthcheck/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-healthcheck/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-service-healthcheck/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-service-removal/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-removal/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-service-removal/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-version/kev.yaml
+++ b/pkg/kev/testdata/reconcile-version/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-version/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-volume-add/kev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-add/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-volume-add/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-volume-edit/kev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-edit/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-volume-edit/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/reconcile-volume-removal/kev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-removal/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/reconcile-volume-removal/docker-compose.yaml
 environments:

--- a/pkg/kev/testdata/validation/kev.yaml
+++ b/pkg/kev/testdata/validation/kev.yaml
@@ -1,3 +1,4 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
 compose:
   - testdata/validation/docker-compose.yaml
 environments:

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -22,6 +22,7 @@ import (
 
 // Manifest contains the tracked project's docker-compose sources and deployment environments
 type Manifest struct {
+	Id           string       `yaml:"id,omitempty" json:"id,omitempty"`
 	Sources      *Sources     `yaml:"compose,omitempty" json:"compose,omitempty"`
 	Environments Environments `yaml:"environments,omitempty" json:"environments,omitempty"`
 	Skaffold     string       `yaml:"skaffold,omitempty" json:"skaffold,omitempty"`


### PR DESCRIPTION
Resolves #358 

## Summary

Extends the project manifest with an UUID generated id field.

## Changes

- Updated the `Manifest` struct with `Id` attribute.
- Added new tests to cover the new Id attribute.
- Moved older tests based on the testing pkg that were affected by new Id attribute to gingko BDD tests.
- Updated testdata fixtures to include the `id` attribute.