### PR TITLE
Respect and support service extensions in environment overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,18 @@
 **/kev.yml
 **/docker-compose.kev.*.yaml
 k8s/*
+docker-compose.yaml
 !/pkg/kev/testdata/**/*.yaml
 !/examples/**/*.yaml
+skaffold.yaml
 
 ### IDEs ###
 .idea/*
-/bin/
+
+# Build binary
+bin/*
+dist/*
+release/*
 
 ### Git meld ###
 *.orig

--- a/pkg/kev/manifest_test.go
+++ b/pkg/kev/manifest_test.go
@@ -70,7 +70,12 @@ var _ = Describe("Manifest", func() {
 			It("merged the environment extensions into sources", func() {
 				mergedSvc, _ := merged.GetService("db")
 				envSvc, _ := env.GetService("db")
-				Expect(mergedSvc.Extensions["x-an-extension"]).To(Equal(envSvc.Extensions["x-an-extension"]))
+
+				mergedSvcExt := mergedSvc.Extensions["x-an-extension"].(map[string]interface{})
+				envSvcExt := envSvc.Extensions["x-an-extension"].(map[string]interface{})
+
+				Expect(mergedSvcExt["key"]).To(Equal("value"))
+				Expect(mergedSvcExt["override-key"]).To(Equal(envSvcExt["override-key"]))
 			})
 
 			It("merged the environment env var overrides into sources", func() {

--- a/pkg/kev/manifest_test.go
+++ b/pkg/kev/manifest_test.go
@@ -67,6 +67,12 @@ var _ = Describe("Manifest", func() {
 				Expect(mergedSvc.Labels).To(Equal(envSvc.Labels))
 			})
 
+			It("merged the environment extensions into sources", func() {
+				mergedSvc, _ := merged.GetService("db")
+				envSvc, _ := env.GetService("db")
+				Expect(mergedSvc.Extensions["x-an-extension"]).To(Equal(envSvc.Extensions["x-an-extension"]))
+			})
+
 			It("merged the environment env var overrides into sources", func() {
 				mergedSvc, _ := merged.GetService("db")
 				envSvc, _ := env.GetService("db")

--- a/pkg/kev/manifest_test.go
+++ b/pkg/kev/manifest_test.go
@@ -68,14 +68,21 @@ var _ = Describe("Manifest", func() {
 			})
 
 			It("merged the environment extensions into sources", func() {
+				sources, _ := manifest.SourcesToComposeProject()
+
+				srcSvc, _ := sources.GetService("db")
 				mergedSvc, _ := merged.GetService("db")
 				envSvc, _ := env.GetService("db")
 
-				mergedSvcExt := mergedSvc.Extensions["x-an-extension"].(map[string]interface{})
-				envSvcExt := envSvc.Extensions["x-an-extension"].(map[string]interface{})
+				Expect(srcSvc.Extensions).To(HaveLen(1))
+				Expect(mergedSvc.Extensions).To(HaveLen(2))
+				Expect(mergedSvc.Extensions["x-other-extension"]).To(Equal(envSvc.Extensions["x-other-extension"]))
 
-				Expect(mergedSvcExt["key"]).To(Equal("value"))
-				Expect(mergedSvcExt["override-key"]).To(Equal(envSvcExt["override-key"]))
+				mergedSvcAnExt := mergedSvc.Extensions["x-an-extension"].(map[string]interface{})
+				envSvcAnExt := envSvc.Extensions["x-an-extension"].(map[string]interface{})
+
+				Expect(mergedSvcAnExt["key"]).To(Equal("value"))
+				Expect(mergedSvcAnExt["override-key"]).To(Equal(envSvcAnExt["override-key"]))
 			})
 
 			It("merged the environment env var overrides into sources", func() {

--- a/pkg/kev/override.go
+++ b/pkg/kev/override.go
@@ -173,6 +173,9 @@ func (o *composeOverride) mergeServicesInto(p *ComposeProject) error {
 		if err := mergo.Merge(&base.Labels, &override.Labels, mergo.WithOverride); err != nil {
 			return errors.Wrapf(err, "cannot merge labels for service %s", override.Name)
 		}
+		if err := mergo.Merge(&base.Extensions, &override.Extensions, mergo.WithOverride); err != nil {
+			return errors.Wrapf(err, "cannot merge extensions for service %s", override.Name)
+		}
 		if err := mergo.Merge(&base.Environment, &override.Environment, mergo.WithOverride); err != nil {
 			return errors.Wrapf(err, "cannot merge env vars for service %s", override.Name)
 		}

--- a/pkg/kev/services.go
+++ b/pkg/kev/services.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newServiceConfig(s composego.ServiceConfig) (ServiceConfig, error) {
-	config := ServiceConfig{Name: s.Name, Labels: s.Labels, Environment: s.Environment}
+	config := ServiceConfig{Name: s.Name, Labels: s.Labels, Environment: s.Environment, Extensions: s.Extensions}
 	return config, config.validate()
 }
 

--- a/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
@@ -19,7 +19,7 @@ services:
       kev.workload.service-account-name: default
       kev.workload.type: StatefulSet
     x-an-extension:
-      key: "value"
+      override-key: "value-overridden"
     environment:
       - OVERRIDE_ME_EMPTY=empty-overridden
       - OVERRIDE_ME_WITH_VAL=val-overridden

--- a/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
@@ -20,6 +20,8 @@ services:
       kev.workload.type: StatefulSet
     x-an-extension:
       override-key: "value-overridden"
+    x-other-extension:
+      key: "value-other"
     environment:
       - OVERRIDE_ME_EMPTY=empty-overridden
       - OVERRIDE_ME_WITH_VAL=val-overridden

--- a/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/merge/docker-compose.kev.dev.yaml
@@ -18,6 +18,8 @@ services:
       kev.workload.rolling-update-max-surge: "1"
       kev.workload.service-account-name: default
       kev.workload.type: StatefulSet
+    x-an-extension:
+      key: "value"
     environment:
       - OVERRIDE_ME_EMPTY=empty-overridden
       - OVERRIDE_ME_WITH_VAL=val-overridden

--- a/pkg/kev/testdata/merge/docker-compose.yaml
+++ b/pkg/kev/testdata/merge/docker-compose.yaml
@@ -13,6 +13,9 @@ services:
       - MYSQL_PASSWORD=wordpress
       - OVERRIDE_ME_EMPTY
       - OVERRIDE_ME_WITH_VAL=value
+    x-an-extension:
+      key: "value"
+      override-key: "value"
 volumes:
   db_data:
 

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -64,6 +64,7 @@ type ServiceConfig struct {
 	Name        string                      `yaml:"-" json:"-" diff:"name"`
 	Labels      composego.Labels            `yaml:",omitempty" json:"labels,omitempty" diff:"labels"`
 	Environment composego.MappingWithEquals `yaml:",omitempty" json:"environment,omitempty" diff:"environment"`
+	Extensions  map[string]interface{}      `yaml:",inline" json:"-"`
 }
 
 type secretHit struct {


### PR DESCRIPTION
Resolves: #361 

This PR implements the following extension strategy:

- Service config extensions can be added to the compose sources.
- Service config extensions can be added to the environment override files.
- Service config extensions will always be merged back to the sources config.
   - **Pre merge**: If an extension does not exist in the source ... **Post merge**: it will be added to the source.
   - **Pre merge**: If an extension exists in the source ... **Post merge**: it will be merged in the source, with the environment 
   override extension entries overriding the source's entries.
- Extensions are not reconciled.

This strategy allows us to add extensions to environment overrides, that will persist even if they don't exist in the original compose sources. And, merge in overrides if compose sources already contain the extension.

