### PR TITLE
Derive environment override file name from kev manifest file name. 

### DIFF
--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -29,14 +29,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ManifestName main application manifest
-	ManifestName = "kev.yaml"
-)
-
 const (
 	// SandboxEnv is a default environment name
 	SandboxEnv = "dev"
+)
+
+var (
+	// ManifestFilename is a name of main application manifest file
+	ManifestFilename = "kev.yaml"
 )
 
 // InitProjectWithOptions initialises a kev project using provided options
@@ -50,7 +50,7 @@ func InitProjectWithOptions(workingDir string, opts InitOptions) (WritableResult
 
 	out = append(out, WritableResult{
 		WriterTo: m,
-		FilePath: path.Join(workingDir, ManifestName),
+		FilePath: path.Join(workingDir, ManifestFilename),
 	})
 	out = append(out, m.Environments.toWritableResults()...)
 

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -29,10 +29,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
+var (
 	// ManifestName main application manifest
 	ManifestName = "kev.yaml"
-	SandboxEnv   = "dev"
+)
+
+const (
+	// SandboxEnv is a default environment name
+	SandboxEnv = "dev"
 )
 
 // InitProjectWithOptions initialises a kev project using provided options

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -47,12 +47,17 @@ func NewManifest(files []string, workingDir string) (*Manifest, error) {
 
 // LoadManifest returns application manifests.
 func LoadManifest(workingDir string) (*Manifest, error) {
-	data, err := ioutil.ReadFile(path.Join(workingDir, ManifestName))
+	data, err := ioutil.ReadFile(path.Join(workingDir, ManifestFilename))
 	if err != nil {
 		return nil, err
 	}
 	var m *Manifest
 	return m, yaml.Unmarshal(data, &m)
+}
+
+// GetManifestName returns base manifest file name (without extension)
+func GetManifestName() string {
+	return strings.TrimSuffix(ManifestFilename, filepath.Ext(ManifestFilename))
 }
 
 // WriteTo writes out a manifest to a writer.
@@ -119,8 +124,6 @@ func (m *Manifest) CalculateSourcesBaseOverride(opts ...BaseOverrideOpts) (*Mani
 func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 	fileNameTemplate := m.GetEnvironmentFileNameTemplate()
 
-	symbol := strings.TrimSuffix(ManifestName, filepath.Ext(ManifestName))
-
 	m.Environments = Environments{}
 	if !contains(candidates, SandboxEnv) {
 		candidates = append(candidates, SandboxEnv)
@@ -131,7 +134,7 @@ func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 		m.Environments = append(m.Environments, &Environment{
 			Name:     env,
 			override: override,
-			File:     path.Join(m.getWorkingDir(), fmt.Sprintf(fileNameTemplate, symbol, env)),
+			File:     path.Join(m.getWorkingDir(), fmt.Sprintf(fileNameTemplate, GetManifestName(), env)),
 		})
 	}
 	return m
@@ -289,9 +292,9 @@ func ManifestExistsForPath(manifestPath string) bool {
 }
 
 func EnsureFirstInit(wd string) error {
-	manifestPath := path.Join(wd, ManifestName)
+	manifestPath := path.Join(wd, ManifestFilename)
 	if ManifestExistsForPath(manifestPath) {
-		err := fmt.Errorf("%s already exists at: %s", ManifestName, manifestPath)
+		err := fmt.Errorf("%s already exists at: %s", ManifestFilename, manifestPath)
 		return err
 	}
 	return nil

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -119,6 +119,8 @@ func (m *Manifest) CalculateSourcesBaseOverride(opts ...BaseOverrideOpts) (*Mani
 func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 	fileNameTemplate := m.GetEnvironmentFileNameTemplate()
 
+	symbol := strings.TrimSuffix(ManifestName, filepath.Ext(ManifestName))
+
 	m.Environments = Environments{}
 	if !contains(candidates, SandboxEnv) {
 		candidates = append(candidates, SandboxEnv)
@@ -129,7 +131,7 @@ func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 		m.Environments = append(m.Environments, &Environment{
 			Name:     env,
 			override: override,
-			File:     path.Join(m.getWorkingDir(), fmt.Sprintf(fileNameTemplate, env)),
+			File:     path.Join(m.getWorkingDir(), fmt.Sprintf(fileNameTemplate, symbol, env)),
 		})
 	}
 	return m
@@ -141,7 +143,7 @@ func (m *Manifest) GetEnvironmentFileNameTemplate() string {
 	firstSrc := filepath.Base(m.Sources.Files[0])
 	parts := strings.Split(firstSrc, ".")
 	ext := parts[len(parts)-1]
-	return strings.ReplaceAll(firstSrc, ext, "kev.%s."+ext)
+	return strings.ReplaceAll(firstSrc, ext, "%s.%s."+ext)
 }
 
 // ReconcileConfig reconciles config changes with docker-compose sources against deployment environments.

--- a/pkg/kev/manifest_test.go
+++ b/pkg/kev/manifest_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Manifest", func() {
 			})
 
 			It("returns environment file name template as expected", func() {
-				Expect(m.GetEnvironmentFileNameTemplate()).To(Equal("my-custom-docker-compose.kev.%s.yaml"))
+				Expect(m.GetEnvironmentFileNameTemplate()).To(Equal("my-custom-docker-compose.%s.%s.yaml"))
 			})
 		})
 
@@ -140,7 +140,7 @@ var _ = Describe("Manifest", func() {
 			})
 
 			It("returns environment file name template as expected", func() {
-				Expect(m.GetEnvironmentFileNameTemplate()).To(Equal("compose.kev.%s.yml"))
+				Expect(m.GetEnvironmentFileNameTemplate()).To(Equal("compose.%s.%s.yml"))
 			})
 		})
 	})

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -745,7 +745,7 @@ func ActivateSkaffoldDevLoop(workDir string) (string, *SkaffoldManifest, error) 
 
 	msg := fmt.Sprintf(`
 	If you don't currently have skaffold.yaml in your project you may bootstrap a new one with "skaffold init" command.
-	Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in %s!`, ManifestName)
+	Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in %s!`, ManifestFilename)
 
 	if len(manifest.Skaffold) == 0 {
 		return "", nil, errors.New("Can't activate Skaffold dev loop. Kev wasn't initialized with --skaffold." + msg)

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -743,9 +743,9 @@ func ActivateSkaffoldDevLoop(workDir string) (string, *SkaffoldManifest, error) 
 		return "", nil, errors.Wrap(err, "Unable to load app manifest")
 	}
 
-	msg := `
+	msg := fmt.Sprintf(`
 	If you don't currently have skaffold.yaml in your project you may bootstrap a new one with "skaffold init" command.
-	Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in kev.yaml!`
+	Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in %s!`, ManifestName)
 
 	if len(manifest.Skaffold) == 0 {
 		return "", nil, errors.New("Can't activate Skaffold dev loop. Kev wasn't initialized with --skaffold." + msg)


### PR DESCRIPTION
Resolves: #383 

This PR modifies how the environment overrides are named. The suffix is now extracted from the ManifestName rather than being fixed. 