### PR TITLE
Support dependent env vars

### DIFF
--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -700,7 +700,7 @@ All traffic on the port you specify will be forwarded to the service allowing an
 
 Again, it is ideal for exposing a service or app to the internet under a single IP address.
 
-Practically, in non development environments, a LoadBalancer will be used to route traffic to an Ingress to expose multiple services under the same IP address and keep your costs down.     
+Practically, in non development environments, a LoadBalancer will be used to route traffic to an Ingress to expose multiple services under the same IP address and keep your costs down.
 
 
 ## kev.service.nodeport.port
@@ -840,6 +840,21 @@ services:
       ...
     environment:
       ENV_VAR_A: some-literal-value  # Literal value
+```
+
+When there is a need to reference any dependent environment variables it can be achieved by using double curly braces
+
+> Environment variable with as literal string referencing dependent environment variables:
+```yaml
+version: 3.7
+services:
+  my-service:
+    labels:
+      ...
+    environment:
+      ENV_VAR_A: foo
+      ENV_VAR_B: bar
+      ENV_VAR_C: {{ENV_VAR_A}}/{{ENV_VAR_B}}  # referencing other dependent environment variables
 ```
 
 ## Reference K8s secret key value

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1250,6 +1250,7 @@ func (k *Kubernetes) configPVCVolumeSource(name string, readonly bool) *v1.Volum
 // @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/kubernetes.go#L961
 func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, error) {
 	envs := EnvSort{}
+	envsWithDeps := []v1.EnvVar{}
 
 	// @step load up the environment variables
 	for k, v := range projectService.environment() {
@@ -1347,16 +1348,20 @@ func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, err
 				}, "Unsupported Container resource reference: %s", resource)
 			}
 		default:
-
 			if strings.Contains(*v, "{{") && strings.Contains(*v, "}}") {
 				*v = strings.ReplaceAll(*v, "{{", "$(")
 				*v = strings.ReplaceAll(*v, "}}", ")")
-			}
 
-			envs = append(envs, v1.EnvVar{
-				Name:  k,
-				Value: *v,
-			})
+				envsWithDeps = append(envsWithDeps, v1.EnvVar{
+					Name:  k,
+					Value: *v,
+				})
+			} else {
+				envs = append(envs, v1.EnvVar{
+					Name:  k,
+					Value: *v,
+				})
+			}
 		}
 	}
 
@@ -1364,6 +1369,12 @@ func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, err
 	// we need this because envs are not populated in any random order
 	// this sorting ensures they are populated in a particular order
 	sort.Stable(envs)
+
+	// append dependent env variables at the end to ensure proper expansion in K8s
+	for _, de := range envsWithDeps {
+		envs = append(envs, de)
+	}
+
 	return envs, nil
 }
 

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1347,6 +1347,12 @@ func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, err
 				}, "Unsupported Container resource reference: %s", resource)
 			}
 		default:
+
+			if strings.Contains(*v, "{{") && strings.Contains(*v, "}}") {
+				*v = strings.ReplaceAll(*v, "{{", "$(")
+				*v = strings.ReplaceAll(*v, "}}", ")")
+			}
+
 			envs = append(envs, v1.EnvVar{
 				Name:  k,
 				Value: *v,

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1526,6 +1526,25 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
+		Context("for env dependend vars containing double curly braces e.g. {{OTHER_ENV_VAR_NAME}} ", func() {
+
+			secretRef := "postgres://{{USER}}:{{PASS}}@{{HOST}}:{{PORT}}/{{DB}}"
+
+			BeforeEach(func() {
+				projectService.Environment = composego.MappingWithEquals{
+					"MY_SECRET": &secretRef,
+				}
+			})
+
+			It("expands that env variable value to reference dependet variables", func() {
+				vars, err := k.configEnvs(projectService)
+
+				Expect(vars[0].Value).To(Equal("postgres://$(USER):$(PASS)@$(HOST):$(PORT)/$(DB)"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+		})
+
 		Context("for env vars with symbolic values", func() {
 
 			Context("as secret.secret-name.secret-key", func() {


### PR DESCRIPTION
Resolves: #391 

Compose Environment variables which values are dependent on other environment variables must be ordered properly so that they can be expanded correctly. This PR allows for env variables with templated values that reference other environment variables, e.g.

```yaml
# docker-compose.yaml

environment:
  MY_VAR: {{FOO}}/{{BAR}}
  FOO: foo
  BAR: bar
```

In k8s manifest this will translate to:

```yaml
    spec:
      containers:
        - env:
            - name: FOO
              value: "foo"
            - name: BAR
              value: "bar"
            - name: MY_VAR
              value: "$(FOO)/$(BAR)"
```