### PR TITLE
Ensures dev mode surfaces skaffold related errors properly

### DIFF
--- a/pkg/kev/dev.go
+++ b/pkg/kev/dev.go
@@ -28,6 +28,7 @@ import (
 	"github.com/appvia/kev/pkg/kev/log"
 	kmd "github.com/appvia/komando"
 	"github.com/fsnotify/fsnotify"
+	"github.com/mitchellh/go-wordwrap"
 	"github.com/pkg/errors"
 )
 
@@ -79,11 +80,24 @@ func (r *DevRunner) Run() error {
 
 		skaffoldConfigPath, skaffoldConfig, err := ActivateSkaffoldDevLoop(r.workingDir)
 		if err != nil {
+			r.UI.Output("")
+			r.UI.Output(
+				wordwrap.WrapString(err.Error(), kmd.RecommendedWordWrapLimit),
+				kmd.WithErrorStyle(),
+				kmd.WithIndentChar(kmd.ErrorIndentChar),
+			)
 			return err
 		}
 
 		if err := WriteTo(skaffoldConfigPath, skaffoldConfig); err != nil {
-			return errors.Wrap(err, "Couldn't write Skaffold config")
+			e := errors.Wrap(err, "Couldn't write Skaffold config")
+			r.UI.Output("")
+			r.UI.Output(
+				wordwrap.WrapString(e.Error(), kmd.RecommendedWordWrapLimit),
+				kmd.WithErrorStyle(),
+				kmd.WithIndentChar(kmd.ErrorIndentChar),
+			)
+			return e
 		}
 
 		pr, pw := io.Pipe()
@@ -123,8 +137,6 @@ func (r *DevRunner) Run() error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // Watch continuously watches source compose files & configured environment overrides

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -650,8 +650,8 @@ func ActivateSkaffoldDevLoop(workDir string) (string, *SkaffoldManifest, error) 
 	}
 
 	msg := fmt.Sprintf(`
-	If you don't currently have skaffold.yaml in your project you may bootstrap a new one with "skaffold init" command.
-	Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in %s!`, ManifestFilename)
+If you don't currently have skaffold.yaml in your project you may bootstrap a new one with "skaffold init" command.
+Once you have skaffold.yaml in your project, make sure that Kev references it by adding "skaffold: skaffold.yaml" in %s!`, ManifestFilename)
 
 	if len(manifest.Skaffold) == 0 {
 		return "", nil, errors.New("Can't activate Skaffold dev loop. Kev wasn't initialized with --skaffold." + msg)


### PR DESCRIPTION
Follow up to #440 

Resolves #446 

This PR adds elements missed in #440. Errors around presence of skaffold.yaml manifest are handled and surfaced in the UI.  
