### PR TITLE
Revisit skaffold profiles

### DIFF
--- a/pkg/kev/init.go
+++ b/pkg/kev/init.go
@@ -161,7 +161,7 @@ func (r *InitRunner) CreateOrUpdateSkaffoldManifest() (*SkaffoldManifest, error)
 		// Skaffold manifest already present - add additional profiles to it!
 		// Note: kev will skip profiles with names matching those of existing
 		// profile names defined in Skaffold to avoid profile "hijack".
-		if skManifest, err = AddProfiles(skPath, envs, true); err != nil {
+		if skManifest, err = InjectProfiles(skPath, envs, true); err != nil {
 			initStepError(r.UI, updateStep, initStepUpdateSkaffold, err)
 			return nil, err
 		}

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -64,9 +64,6 @@ const (
 	// SkaffoldFileName is a file name of skaffold manifest
 	SkaffoldFileName = "skaffold.yaml"
 
-	// ProfileNamePrefix is a prefix to the added skaffold aprofile
-	ProfileNamePrefix = "kev-"
-
 	// EnvProfileNameSuffix is a suffix added to environment specific profile name
 	EnvProfileNameSuffix = "-env"
 
@@ -256,10 +253,10 @@ func (s *SkaffoldManifest) SetProfiles(envs []string) {
 // AdditionalProfiles adds additional Skaffold profiles
 func (s *SkaffoldManifest) AdditionalProfiles() {
 
-	if !s.profileNameExist(ProfileNamePrefix + "ci-local-build-no-push") {
+	if !s.profileNameExist("ci-local-build-no-push") {
 		// Helper profile for use in CI pipeline
 		s.Profiles = append(s.Profiles, latest.Profile{
-			Name: ProfileNamePrefix + "ci-local-build-no-push",
+			Name: "ci-local-build-no-push",
 			Pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					BuildType: latest.BuildType{
@@ -274,10 +271,10 @@ func (s *SkaffoldManifest) AdditionalProfiles() {
 		})
 	}
 
-	if !s.profileNameExist(ProfileNamePrefix + "ci-local-build-and-push") {
+	if !s.profileNameExist("ci-local-build-and-push") {
 		// Helper profile for use in CI pipeline
 		s.Profiles = append(s.Profiles, latest.Profile{
-			Name: ProfileNamePrefix + "ci-local-build-and-push",
+			Name: "ci-local-build-and-push",
 			Pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					BuildType: latest.BuildType{

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -106,9 +106,9 @@ func LoadSkaffoldManifest(path string) (*SkaffoldManifest, error) {
 	return s, yaml.Unmarshal(data, &s)
 }
 
-// AddProfiles injects kev profiles to existing Skaffold manifest
+// InjectProfiles injects kev profiles to existing Skaffold manifest
 // Note, if profile name already exists in the skaffold manifest then profile won't be added
-func AddProfiles(path string, envs []string, includeAdditional bool) (*SkaffoldManifest, error) {
+func InjectProfiles(path string, envs []string, includeAdditional bool) (*SkaffoldManifest, error) {
 	skaffold, err := LoadSkaffoldManifest(path)
 	if err != nil {
 		return nil, err
@@ -638,7 +638,7 @@ Once you have skaffold.yaml in your project, make sure that Kev references it by
 	}
 
 	// Reconcile skaffold config and add potentially missing profiles before starting dev loop
-	reconciledSkaffoldConfig, err := AddProfiles(configPath, manifest.GetEnvironmentsNames(), true)
+	reconciledSkaffoldConfig, err := InjectProfiles(configPath, manifest.GetEnvironmentsNames(), true)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "Couldn't reconcile Skaffold config - required profiles haven't been added.")
 	}

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -307,40 +307,41 @@ func (s *SkaffoldManifest) SetProfiles(envs []string) {
 // SetAdditionalProfiles adds additional Skaffold profiles
 func (s *SkaffoldManifest) SetAdditionalProfiles() {
 
-	if !s.profileNameExist("ci-local-build-no-push") {
-		// Helper profile for use in CI pipeline
-		s.Profiles = append(s.Profiles, latest.Profile{
-			Name: "ci-local-build-no-push",
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{
-							Push: &disabled,
-						},
+	s.AddProfileIfNotPresent(latest.Profile{
+		Name: "ci-local-build-no-push",
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				BuildType: latest.BuildType{
+					LocalBuild: &latest.LocalBuild{
+						Push: &disabled,
 					},
 				},
-				// deploy is a no-op intentionally
-				Deploy: latest.DeployConfig{},
 			},
-		})
-	}
+			// deploy is a no-op intentionally
+			Deploy: latest.DeployConfig{},
+		},
+	})
 
-	if !s.profileNameExist("ci-local-build-and-push") {
-		// Helper profile for use in CI pipeline
-		s.Profiles = append(s.Profiles, latest.Profile{
-			Name: "ci-local-build-and-push",
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{
-							Push: &enabled,
-						},
+	s.AddProfileIfNotPresent(latest.Profile{
+		Name: "ci-local-build-and-push",
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				BuildType: latest.BuildType{
+					LocalBuild: &latest.LocalBuild{
+						Push: &enabled,
 					},
 				},
-				// deploy is a no-op intentionally
-				Deploy: latest.DeployConfig{},
 			},
-		})
+			// deploy is a no-op intentionally
+			Deploy: latest.DeployConfig{},
+		},
+	})
+}
+
+// AddProfileIfNotPresent adds Skaffold profile unless profile with that name already exists
+func (s *SkaffoldManifest) AddProfileIfNotPresent(p latest.Profile) {
+	if !s.profileNameExist(p.Name) {
+		s.Profiles = append(s.Profiles, p)
 	}
 }
 

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -91,7 +91,7 @@ func NewSkaffoldManifest(envs []string, project *ComposeProject) (*SkaffoldManif
 	manifest := BaseSkaffoldManifest()
 	manifest.SetBuildArtifacts(analysis, project)
 	manifest.SetProfiles(envs)
-	manifest.AdditionalProfiles()
+	manifest.SetAdditionalProfiles()
 
 	return manifest, nil
 }
@@ -116,7 +116,7 @@ func AddProfiles(path string, envs []string, includeAdditional bool) (*SkaffoldM
 
 	skaffold.SetProfiles(envs)
 	if includeAdditional {
-		skaffold.AdditionalProfiles()
+		skaffold.SetAdditionalProfiles()
 	}
 
 	return skaffold, nil
@@ -250,8 +250,8 @@ func (s *SkaffoldManifest) SetProfiles(envs []string) {
 	}
 }
 
-// AdditionalProfiles adds additional Skaffold profiles
-func (s *SkaffoldManifest) AdditionalProfiles() {
+// SetAdditionalProfiles adds additional Skaffold profiles
+func (s *SkaffoldManifest) SetAdditionalProfiles() {
 
 	if !s.profileNameExist("ci-local-build-no-push") {
 		// Helper profile for use in CI pipeline

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -388,27 +388,21 @@ func collectBuildArtifacts(analysis *Analysis, project *ComposeProject) map[stri
 			svcImageNameFromContext = contextParts[len(contextParts)-1]
 		}
 
-		if len(analysis.Images) > 0 {
-			// Check whether images detected by Analysis contain service image name derived from the
-			// context as that's the best we can do in order to match a service to a corresponding
-			// docker registry image.
-			// If no docker registry image was detected then we use service name as docker image name.
-			for _, image := range analysis.Images {
-				if len(image) > 0 && strings.HasSuffix(image, svcImageNameFromContext) {
-					buildArtifacts[context] = image
-					break
-				} else {
-					buildArtifacts[context] = svcImageNameFromContext
-				}
-			}
-		} else {
-			// No Images detected by analysis - usually due to the absence of K8s manifests
-			// which Analysis uses to determine which images are in use.
-			// Add build artifact with details derived from analysis detected Dockerfiles
-			// Note: This may not be always accurate!
-			buildArtifacts[context] = svcImageNameFromContext
-		}
+		// NOTE: This may not be always accurate!
+		buildArtifacts[context] = svcImageNameFromContext
 
+		// Check whether images detected by Analysis contain service image name derived from the
+		// context as that's the best we can do in order to match a service to a corresponding
+		// docker registry image.
+		//
+		// NOTE: When *NO* Images are detected by analysis this is usually due to the absence of K8s
+		// manifests which Analysis uses to determine which images are in use.
+		for _, image := range analysis.Images {
+			if len(image) > 0 && strings.HasSuffix(image, svcImageNameFromContext) {
+				buildArtifacts[context] = image
+				break
+			}
+		}
 	}
 
 	// Extract images referenced by a Docker Compose project and map them to their respective build contexts (if present)

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -27,7 +27,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -394,10 +393,8 @@ func collectBuildArtifacts(analysis *Analysis, project *ComposeProject) map[stri
 			// context as that's the best we can do in order to match a service to a corresponding
 			// docker registry image.
 			// If no docker registry image was detected then we use service name as docker image name.
-			re := regexp.MustCompile(fmt.Sprintf(`.*\/%s`, svcImageNameFromContext))
-
 			for _, image := range analysis.Images {
-				if found := re.FindAllStringSubmatchIndex(image, -1); found != nil {
+				if len(image) > 0 && strings.HasSuffix(image, svcImageNameFromContext) {
 					buildArtifacts[context] = image
 					break
 				} else {

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Skaffold", func() {
 		})
 	})
 
-	Describe("AddProfiles", func() {
+	Describe("InjectProfiles", func() {
 		var (
 			skaffoldManifest          *kev.SkaffoldManifest
 			existingSkaffoldPath      string
@@ -287,7 +287,7 @@ var _ = Describe("Skaffold", func() {
 			// Note, example skaffold already contains dev environment profile
 			BeforeEach(func() {
 				envs := []string{"prod"}
-				skaffoldManifest, err = kev.AddProfiles(existingSkaffoldPath, envs, includeAdditionalProfiles)
+				skaffoldManifest, err = kev.InjectProfiles(existingSkaffoldPath, envs, includeAdditionalProfiles)
 			})
 
 			It("adds that profile to skaffold manifest", func() {
@@ -302,7 +302,7 @@ var _ = Describe("Skaffold", func() {
 			// Note, example skaffold already contains dev environment profile
 			BeforeEach(func() {
 				envs := []string{"dev"}
-				skaffoldManifest, err = kev.AddProfiles(existingSkaffoldPath, envs, includeAdditionalProfiles)
+				skaffoldManifest, err = kev.InjectProfiles(existingSkaffoldPath, envs, includeAdditionalProfiles)
 			})
 
 			It("doesn't add it to the skaffold manifest", func() {

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -480,7 +480,7 @@ var _ = Describe("Skaffold", func() {
 			})
 		})
 
-		Context("with ot without images detected by Skaffold analysis", func() {
+		Context("with or without images detected by Skaffold analysis", func() {
 			BeforeEach(func() {
 				skaffoldManifest = &kev.SkaffoldManifest{}
 			})

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -157,10 +157,10 @@ var _ = Describe("Skaffold", func() {
 
 	})
 
-	Describe("AdditionalProfiles", func() {
+	Describe("SetAdditionalProfiles", func() {
 
 		manifest := kev.BaseSkaffoldManifest()
-		manifest.AdditionalProfiles()
+		manifest.SetAdditionalProfiles()
 
 		It("adds all additional profiles", func() {
 			Expect(manifest.Profiles).To(HaveLen(2))
@@ -207,8 +207,8 @@ var _ = Describe("Skaffold", func() {
 		When("profile of the same name already exists in skaffold profiles", func() {
 
 			BeforeEach(func() {
-				// explicitly triggering another AdditionalProfiles
-				manifest.AdditionalProfiles()
+				// explicitly triggering another SetAdditionalProfiles
+				manifest.SetAdditionalProfiles()
 			})
 
 			It("doesn't add existing additional profiles again", func() {

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -169,9 +169,9 @@ var _ = Describe("Skaffold", func() {
 		Context("ci-local-build-no-push", func() {
 			enabled := false
 
-			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
+			It("adds additional profiles to the skaffold manifest", func() {
 				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-ci-local-build-no-push",
+					Name: "ci-local-build-no-push",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							BuildType: latest.BuildType{
@@ -188,9 +188,9 @@ var _ = Describe("Skaffold", func() {
 		Context("ci-local-build-and-push", func() {
 			enabled := true
 
-			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
+			It("adds additional profiles to the skaffold manifest", func() {
 				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-ci-local-build-and-push",
+					Name: "ci-local-build-and-push",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							BuildType: latest.BuildType{

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -58,13 +58,25 @@ var _ = Describe("Skaffold", func() {
 	})
 
 	Describe("BaseSkaffoldManifest", func() {
-		It("returns base skaffold", func() {
+		It("returns base skaffold with global pipeline build configuration", func() {
 			Expect(kev.BaseSkaffoldManifest()).To(Equal(
 				&kev.SkaffoldManifest{
 					APIVersion: latest.Version,
 					Kind:       "Config",
 					Metadata: latest.Metadata{
 						Name: "App",
+					},
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							BuildType: latest.BuildType{
+								LocalBuild: &latest.LocalBuild{},
+							},
+							TagPolicy: latest.TagPolicy{
+								GitTagger: &latest.GitTagger{
+									Variant: "Tags",
+								},
+							},
+						},
 					},
 				},
 			))
@@ -100,16 +112,7 @@ var _ = Describe("Skaffold", func() {
 
 			It("generates correct pipeline Build section for each environment", func() {
 				for _, p := range manifest.Profiles {
-					Expect(p.Build).To(Equal(latest.BuildConfig{
-						BuildType: latest.BuildType{
-							LocalBuild: &latest.LocalBuild{},
-						},
-						TagPolicy: latest.TagPolicy{
-							GitTagger: &latest.GitTagger{
-								Variant: "Tags",
-							},
-						},
-					}))
+					Expect(p.Build).To(Equal(latest.BuildConfig{}))
 				}
 			})
 

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Skaffold", func() {
 					APIVersion: latest.Version,
 					Kind:       "Config",
 					Metadata: latest.Metadata{
-						Name: "KevApp",
+						Name: "App",
 					},
 				},
 			))
@@ -99,14 +99,10 @@ var _ = Describe("Skaffold", func() {
 			})
 
 			It("generates correct pipeline Build section for each environment", func() {
-				enabled := true
-
 				for _, p := range manifest.Profiles {
 					Expect(p.Build).To(Equal(latest.BuildConfig{
 						BuildType: latest.BuildType{
-							LocalBuild: &latest.LocalBuild{
-								Push: &enabled,
-							},
+							LocalBuild: &latest.LocalBuild{},
 						},
 						TagPolicy: latest.TagPolicy{
 							GitTagger: &latest.GitTagger{
@@ -167,51 +163,15 @@ var _ = Describe("Skaffold", func() {
 		manifest.AdditionalProfiles()
 
 		It("adds all additional profiles", func() {
-			Expect(manifest.Profiles).To(HaveLen(4))
+			Expect(manifest.Profiles).To(HaveLen(2))
 		})
 
-		Context("minikube", func() {
-			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
-				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-minikube",
-					Activation: []latest.Activation{
-						{
-							KubeContext: "minikube",
-						},
-					},
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
-							KubeContext: "minikube",
-						},
-					},
-				}))
-			})
-		})
-
-		Context("docker-desktop", func() {
-			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
-				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-docker-desktop",
-					Activation: []latest.Activation{
-						{
-							KubeContext: "docker-desktop",
-						},
-					},
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
-							KubeContext: "docker-desktop",
-						},
-					},
-				}))
-			})
-		})
-
-		Context("ci-build-no-push", func() {
+		Context("ci-local-build-no-push", func() {
 			enabled := false
 
 			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
 				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-ci-build-no-push",
+					Name: "kev-ci-local-build-no-push",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							BuildType: latest.BuildType{
@@ -225,12 +185,12 @@ var _ = Describe("Skaffold", func() {
 			})
 		})
 
-		Context("ci-build-and-push", func() {
+		Context("ci-local-build-and-push", func() {
 			enabled := true
 
 			It("adds additional profiles to the skaffold manifest with name containing kev defined prefix", func() {
 				Expect(manifest.Profiles).To(ContainElement(latest.Profile{
-					Name: "kev-ci-build-and-push",
+					Name: "kev-ci-local-build-and-push",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							BuildType: latest.BuildType{
@@ -252,7 +212,7 @@ var _ = Describe("Skaffold", func() {
 			})
 
 			It("doesn't add existing additional profiles again", func() {
-				Expect(manifest.Profiles).To(HaveLen(4))
+				Expect(manifest.Profiles).To(HaveLen(2))
 			})
 		})
 	})


### PR DESCRIPTION
Resolves #411 

This PR introduces the following changes:

* Removes unnecessary local profile for `minikube` and `docker-desktop` as these are handled natively.
* Removes `Push` option in Build phase of each environment profile - local profiles will never push (unless overridden), and when remote contexts are in use then push will happen automatically (unless overridden).  
* Simplifies naming convention for the additional profiles.
* Changes build artefact discovery algorithm - native Skaffold Analysis, followed by discovery from base docker-compose file.
* Adds `UpdateSkaffoldBuildArtifacts` method to enabled automatic build artefacts list update in `skaffold.yaml` - this happens at `render` time given the project was initialised with skaffold support.
* Moves "Build" part of the pipeline from individual profiles to the top level (global) pipeline for better readability.
* Minor Skaffold profiles refactoring changes.