### PR TITLE
For UI, use app name defined in the CLI's root cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,13 @@ else
 	VERSION ?= $(GIT_LAST_TAG)
 endif
 
-LFLAGS ?= -X github.com/appvia/kev/pkg/${NAME}.Tag=${GIT_LAST_TAG} -X github.com/appvia/kev/pkg/${NAME}.GitSHA=${GIT_SHA} -X github.com/appvia/kev/pkg/${NAME}.Compiled=${BUILD_TIME} -X github.com/appvia/kev/pkg/${NAME}.Release=${VERSION} -X github.com/appvia/kev/pkg/${NAME}.GitBranch=${GIT_BRANCH}
+LFLAGS ?= -X 'github.com/appvia/kev/pkg/config.AppName=${NAME}' \
+		  -X 'github.com/appvia/kev/pkg/config.Tag=${GIT_LAST_TAG}' \
+ 		  -X 'github.com/appvia/kev/pkg/config.GitSHA=${GIT_SHA}' \
+ 		  -X 'github.com/appvia/kev/pkg/config.Compiled=${BUILD_TIME}' \
+ 		  -X 'github.com/appvia/kev/pkg/config.Release=${VERSION}' \
+ 		  -X 'github.com/appvia/kev/pkg/config.GitBranch=${GIT_BRANCH}'
+
 CLI_PLATFORMS=darwin linux windows
 CLI_ARCHITECTURES=amd64 arm64
 

--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -152,6 +152,7 @@ func runDevCmd(cmd *cobra.Command, args []string) error {
 	wd := "."
 
 	return kev.DevWithOptions(wd,
+		kev.WithAppName(rootCmd.Use),
 		kev.WithEventHandler(eventHandler),
 		kev.WithSkaffold(skaffold),
 		kev.WithK8sNamespace(namespace),

--- a/cmd/kev/cmd/init.go
+++ b/cmd/kev/cmd/init.go
@@ -82,6 +82,7 @@ func runInitCmd(cmd *cobra.Command, _ []string) error {
 	// This ensures created manifest yaml entries are portable between users and require no path fixing.
 	wd := "."
 	return kev.InitProjectWithOptions(wd,
+		kev.WithAppName(rootCmd.Use),
 		kev.WithComposeSources(files),
 		kev.WithEnvs(envs),
 		kev.WithSkaffold(skaffold))

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -91,6 +91,7 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 	wd := "."
 
 	return kev.RenderProjectWithOptions(wd,
+		kev.WithAppName(rootCmd.Use),
 		kev.WithManifestFormat(format),
 		kev.WithManifestsAsSingleFile(singleFile),
 		kev.WithOutputDir(dir),

--- a/cmd/kev/cmd/root.go
+++ b/cmd/kev/cmd/root.go
@@ -25,7 +25,6 @@ import (
 
 var silentErr = errors.New("silentErr")
 var rootCmd = &cobra.Command{
-	Use:              "kev",
 	Short:            "Develop Kubernetes apps iteratively using Docker-Compose.",
 	TraverseChildren: true,
 	SilenceErrors:    true,
@@ -57,7 +56,9 @@ func init() {
 }
 
 // Execute command
-func Execute() {
+func Execute(appName string) {
+	rootCmd.Use = appName
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/kev/cmd/root.go
+++ b/cmd/kev/cmd/root.go
@@ -20,12 +20,14 @@ import (
 	"errors"
 	"os"
 
+	"github.com/appvia/kev/pkg/kev/config"
 	"github.com/spf13/cobra"
 )
 
 var silentErr = errors.New("silentErr")
 var rootCmd = &cobra.Command{
 	Short:            "Develop Kubernetes apps iteratively using Docker-Compose.",
+	Use:              config.AppName,
 	TraverseChildren: true,
 	SilenceErrors:    true,
 	SilenceUsage:     true,
@@ -56,9 +58,7 @@ func init() {
 }
 
 // Execute command
-func Execute(appName string) {
-	rootCmd.Use = appName
-
+func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/kev/cmd/ux.go
+++ b/cmd/kev/cmd/ux.go
@@ -17,8 +17,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/appvia/kev/pkg/kev/log"
 	"github.com/sirupsen/logrus"
 )
@@ -28,13 +26,4 @@ func setReporting(verbose bool) {
 	if verbose {
 		log.SetLogLevel(logrus.DebugLevel)
 	}
-}
-
-func displayCmdStarted(cmdName string) {
-	_, _ = os.Stdout.Write([]byte("> " + cmdName + "...\n"))
-}
-
-func displayError(err error) error {
-	log.ErrorDetail(err)
-	return err
 }

--- a/cmd/kev/cmd/version.go
+++ b/cmd/kev/cmd/version.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/appvia/kev/pkg/kev"
+	"github.com/appvia/kev/pkg/kev/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,9 +29,9 @@ func init() {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print Kev version",
-	Long:  `All software has versions. This is Kev's`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(kev.Version())
+	Short: "Print version information.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(config.Version())
+		return nil
 	},
 }

--- a/cmd/kev/main.go
+++ b/cmd/kev/main.go
@@ -18,6 +18,8 @@ package main
 
 import "github.com/appvia/kev/cmd/kev/cmd"
 
+const AppName = "kev"
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(AppName)
 }

--- a/cmd/kev/main.go
+++ b/cmd/kev/main.go
@@ -18,8 +18,6 @@ package main
 
 import "github.com/appvia/kev/cmd/kev/cmd"
 
-const AppName = "kev"
-
 func main() {
-	cmd.Execute(AppName)
+	cmd.Execute()
 }

--- a/pkg/kev/config/app.go
+++ b/pkg/kev/config/app.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Appvia Ltd <info@appvia.io>
+ * Copyright 2021 Appvia Ltd <info@appvia.io>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package kev
+package config
 
 import (
 	"fmt"
@@ -23,35 +23,42 @@ import (
 )
 
 var (
-	// Prog is the name of the product
-	Prog = "Kev"
+	// AppName is the app's name, can be overridden using ldflags.
+	AppName = "kev"
+
 	// Author is the prog author
 	Author = "Appvia"
+
 	// Email is the default email
 	Email = "info@appvia.io"
-	// Version in computed version
-	version = ""
+
 	// Compiled in the time it was compiling
 	Compiled = "0"
+
 	// GitSHA is the sha this was built off
 	GitSHA = "no gitsha provided"
+
 	// GitBranch is the branch program was built off
 	GitBranch = "no branch provided"
+
 	// Release is the releasing version
 	Release = "latest"
+
 	// Tag is the release tag of the build
 	Tag = ""
 )
 
 // Version returns the proxy version
 func Version() string {
-	if version == "" {
-		tm, err := strconv.ParseInt(Compiled, 10, 64)
-		if err != nil {
-			return "unable to parse compiled time"
-		}
-		version = fmt.Sprintf("%s %s (branch: %s, git+sha: %s, built: %s)", Prog, Release, GitBranch, GitSHA, time.Unix(tm, 0).Format("02-01-2006"))
+	tm, err := strconv.ParseInt(Compiled, 10, 64)
+	if err != nil {
+		return "unable to parse compiled time"
 	}
-
-	return version
+	return fmt.Sprintf("%s %s (branch: %s, git+sha: %s, built: %s)",
+		AppName,
+		Release,
+		GitBranch,
+		GitSHA,
+		time.Unix(tm, 0).Format("02-01-2006"),
+	)
 }

--- a/pkg/kev/dev.go
+++ b/pkg/kev/dev.go
@@ -92,7 +92,7 @@ func (r *DevRunner) Run() error {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		catchCtrlC(cancel, r.UI)
+		catchCtrlC(cancel, r.AppName, r.UI)
 
 		skaffoldConfigPath, skaffoldConfig, err := ActivateSkaffoldDevLoop(r.WorkingDir)
 		if err != nil {
@@ -329,7 +329,7 @@ func (r *DevRunner) DisplayLogs(reader io.Reader, ctx context.Context) {
 }
 
 // catchCtrlC catches ctrl+c in dev loop when running Skaffold
-func catchCtrlC(cancel context.CancelFunc, ui kmd.UI) {
+func catchCtrlC(cancel context.CancelFunc, appName string, ui kmd.UI) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals,
 		os.Interrupt,
@@ -350,7 +350,7 @@ func catchCtrlC(cancel context.CancelFunc, ui kmd.UI) {
 			kmd.WithStyle(kmd.LogStyle),
 		)
 		ui.Output(
-			fmt.Sprintf("'%s' will continue to reconcile and re-render K8s manifests for your project.", GetManifestName()),
+			fmt.Sprintf("'%s' will continue to reconcile and re-render K8s manifests for your project.", appName),
 			kmd.WithIndent(1),
 			kmd.WithIndentChar(kmd.LogIndentChar),
 			kmd.WithStyle(kmd.LogStyle),
@@ -364,12 +364,12 @@ func catchCtrlC(cancel context.CancelFunc, ui kmd.UI) {
 	}()
 }
 
-func printDevProjectWithOptionsError(ui kmd.UI) {
+func printDevProjectWithOptionsError(appName string, ui kmd.UI) {
 	ui.Output("")
 	ui.Output("Project had errors during dev.\n"+
-		fmt.Sprintf("'%s' experienced some errors while running dev. The output\n", GetManifestName())+
+		fmt.Sprintf("'%s' experienced some errors while running dev. The output\n", appName)+
 		"above should contain the failure messages. Please correct these errors and\n"+
-		fmt.Sprintf("run '%s dev' again.", GetManifestName()),
+		fmt.Sprintf("run '%s dev' again.", appName),
 		kmd.WithErrorBoldStyle(),
 		kmd.WithIndentChar(kmd.ErrorIndentChar),
 	)

--- a/pkg/kev/init.go
+++ b/pkg/kev/init.go
@@ -242,12 +242,12 @@ func createInitWritableResults(workingDir string, manifest *Manifest, skManifest
 	return out
 }
 
-func printInitProjectWithOptionsError(ui kmd.UI) {
+func printInitProjectWithOptionsError(appName string, ui kmd.UI) {
 	ui.Output("")
 	ui.Output("Project had errors during initialisation.\n"+
-		fmt.Sprintf("'%s' experienced some errors during project initialisation. The output\n", GetManifestName())+
+		fmt.Sprintf("'%s' experienced some errors during project initialisation. The output\n", appName)+
 		"above should contain the failure messages. Please correct these errors and\n"+
-		fmt.Sprintf("run '%s init' again.", GetManifestName()),
+		fmt.Sprintf("run '%s init' again.", appName),
 		kmd.WithErrorBoldStyle(),
 		kmd.WithIndentChar(kmd.ErrorIndentChar),
 	)
@@ -282,7 +282,7 @@ func printInitProjectWithOptionsSuccess(runner *InitRunner, envs Environments) e
 	}
 
 	ui.Output("")
-	ui.Output(fmt.Sprintf("You may now call `%s render` to prepare your project for deployment.", GetManifestName()))
+	ui.Output(fmt.Sprintf("You may now call `%s render` to prepare your project for deployment.", runner.AppName))
 
 	return nil
 }

--- a/pkg/kev/init_errors.go
+++ b/pkg/kev/init_errors.go
@@ -17,7 +17,6 @@
 package kev
 
 import (
-	"fmt"
 	"strings"
 
 	kmd "github.com/appvia/komando"
@@ -56,12 +55,12 @@ deployment environments. Without them a project cannot be initialised.
 
 	initStepParsingComposeConfig: {
 		Error: "Invalid compose source(s)!",
-		ErrorDetails: fmt.Sprintf(`
-The provided compose source(s) are invalid. '%s' requires valid 
+		ErrorDetails: `
+The provided compose source(s) are invalid. 'init' requires valid 
 compose source files - without them a project cannot be initialised or loaded. 
 Use the command 'docker-compose -f <compose-source-file> config'
 to double check your compose source(s) are valid.
-		`, GetManifestName()),
+`,
 	},
 
 	initStepGenerateManifest: {

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -35,12 +35,12 @@ func InitProjectWithOptions(workingDir string, opts ...Options) error {
 
 	results, err := runner.Run()
 	if err != nil {
-		printInitProjectWithOptionsError(ui)
+		printInitProjectWithOptionsError(runner.AppName, ui)
 		return err
 	}
 
 	if err := results.Write(); err != nil {
-		printInitProjectWithOptionsError(ui)
+		printInitProjectWithOptionsError(runner.AppName, ui)
 		return err
 	}
 
@@ -55,7 +55,7 @@ func RenderProjectWithOptions(workingDir string, opts ...Options) error {
 
 	results, err := runner.Run()
 	if err != nil {
-		printRenderProjectWithOptionsError(ui)
+		printRenderProjectWithOptionsError(runner.AppName, ui)
 		return err
 	}
 
@@ -74,7 +74,7 @@ func DevWithOptions(workingDir string, opts ...Options) error {
 	err := runner.Run()
 
 	if err != nil {
-		printDevProjectWithOptionsError(runner.UI)
+		printDevProjectWithOptionsError(runner.AppName, runner.UI)
 		return err
 	}
 

--- a/pkg/kev/project.go
+++ b/pkg/kev/project.go
@@ -26,6 +26,10 @@ import (
 // Init initialises the base project to be used in a runner
 func (p *Project) Init(opts ...Options) {
 	p.SetConfig(opts...)
+	if len(p.AppName) == 0 {
+		p.AppName = GetManifestName()
+	}
+
 	if p.UI == nil {
 		p.UI = kmd.ConsoleUI()
 	}
@@ -127,6 +131,13 @@ func (p *Project) SetConfig(opts ...Options) {
 		o(p, cfg)
 	}
 	p.config = cfg
+}
+
+// WithAppName configures a project app name
+func WithAppName(name string) Options {
+	return func(project *Project, cfg *runConfig) {
+		project.AppName = name
+	}
 }
 
 // WithUI configures a project with a terminal UI implementation

--- a/pkg/kev/project.go
+++ b/pkg/kev/project.go
@@ -19,6 +19,7 @@ package kev
 import (
 	"fmt"
 
+	"github.com/appvia/kev/pkg/kev/config"
 	kmd "github.com/appvia/komando"
 	"github.com/pkg/errors"
 )
@@ -26,8 +27,9 @@ import (
 // Init initialises the base project to be used in a runner
 func (p *Project) Init(opts ...Options) {
 	p.SetConfig(opts...)
+
 	if len(p.AppName) == 0 {
-		p.AppName = GetManifestName()
+		p.AppName = config.AppName
 	}
 
 	if p.UI == nil {

--- a/pkg/kev/render.go
+++ b/pkg/kev/render.go
@@ -221,12 +221,12 @@ func (r *RenderRunner) RenderFromComposeToK8sManifests() (map[string]string, err
 	return results, err
 }
 
-func printRenderProjectWithOptionsError(ui kmd.UI) {
+func printRenderProjectWithOptionsError(appName string, ui kmd.UI) {
 	ui.Output("")
 	ui.Output("Project had errors during render.\n"+
-		fmt.Sprintf("'%s' experienced some errors during project render. The output\n", GetManifestName())+
+		fmt.Sprintf("'%s' experienced some errors during project render. The output\n", appName)+
 		"above should contain the failure messages. Please correct these errors and\n"+
-		fmt.Sprintf("run '%s render' again.", GetManifestName()),
+		fmt.Sprintf("run '%s render' again.", appName),
 		kmd.WithErrorBoldStyle(),
 		kmd.WithIndentChar(kmd.ErrorIndentChar),
 	)

--- a/pkg/kev/render_errors.go
+++ b/pkg/kev/render_errors.go
@@ -72,11 +72,11 @@ run the 'init' command with the '--skaffold' flag.
 
 	renderStepRenderOverlay: {
 		Error: "Cannot overlay environment settings during render!",
-		ErrorDetails: fmt.Sprintf(`
-'%s' cannot super impose environment settings over the compose source values.
+		ErrorDetails: `
+Cannot overlay environment settings over the compose source values.
 This is important as it ensures that project rendered manifests will have 
 environment specific settings.
-		`, GetManifestName()),
+`,
 	},
 }
 

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -66,6 +66,7 @@ type Runner interface {
 // Project is the base struct for all runners.
 // Runners must initialise a project using Init().
 type Project struct {
+	AppName      string
 	WorkingDir   string
 	UI           kmd.UI
 	manifest     *Manifest


### PR DESCRIPTION
Resolves #475 

- The app name is now configured in `main.go`.
- The root cmd is wired to use the app name.
- All runner are now configured to use an app name.