### PR TITLE
Enable volumes reconciliation for extensions.

### DIFF
--- a/pkg/kev/config/svcextensions.go
+++ b/pkg/kev/config/svcextensions.go
@@ -128,6 +128,8 @@ func RequireExtensions() SvcK8sConfigOption {
 	}
 }
 
+// SvcK8sConfigFromCompose creates a K8s service extension from a compose-go service.
+// It extracts and infers values based on rules applied to the compose-go service.
 func SvcK8sConfigFromCompose(svc *composego.ServiceConfig) (SvcK8sConfig, error) {
 	var cfg SvcK8sConfig
 

--- a/pkg/kev/config/svcextensions.go
+++ b/pkg/kev/config/svcextensions.go
@@ -107,16 +107,17 @@ func DefaultSvcK8sConfig() SvcK8sConfig {
 	}
 }
 
-type svcK8sConfigOptions struct {
+type extensionOptions struct {
 	skipValidation bool
 }
 
-// SvcK8sConfigOption will modify parsing behaviour of the x-k8s extension.
-type SvcK8sConfigOption func(*svcK8sConfigOptions)
+// K8sExtensionOption will modify parsing behaviour of the k8s extension.
+type K8sExtensionOption func(*extensionOptions)
 
-func SkipValidation() SvcK8sConfigOption {
-	return func(options *svcK8sConfigOptions) {
-		options.skipValidation = true
+// SkipValidation skips validation when parsing a k8s extension from a service.
+func SkipValidation() K8sExtensionOption {
+	return func(extOpts *extensionOptions) {
+		extOpts.skipValidation = true
 	}
 }
 
@@ -360,8 +361,8 @@ func LivenessProbeFromCompose(svc *composego.ServiceConfig) LivenessProbe {
 }
 
 // ParseSvcK8sConfigFromMap handles the extraction of the k8s-specific extension values from the top level map.
-func ParseSvcK8sConfigFromMap(m map[string]interface{}, opts ...SvcK8sConfigOption) (SvcK8sConfig, error) {
-	var options svcK8sConfigOptions
+func ParseSvcK8sConfigFromMap(m map[string]interface{}, opts ...K8sExtensionOption) (SvcK8sConfig, error) {
+	var options extensionOptions
 	for _, o := range opts {
 		o(&options)
 	}

--- a/pkg/kev/config/volextensions.go
+++ b/pkg/kev/config/volextensions.go
@@ -100,6 +100,7 @@ func DefaultVolK8sConfig() VolK8sConfig {
 }
 
 // VolK8sConfigFromCompose returns a VolK8sConfig from a compose-go VolumeConfig
+// It extracts and infers values based on rules applied to the compose-go volume.
 func VolK8sConfigFromCompose(vol *composego.VolumeConfig) (VolK8sConfig, error) {
 	cfg := DefaultVolK8sConfig()
 	volFromMap, err := ParseVolK8sConfigFromMap(vol.Extensions)

--- a/pkg/kev/config/volextensions.go
+++ b/pkg/kev/config/volextensions.go
@@ -102,13 +102,18 @@ func DefaultVolK8sConfig() VolK8sConfig {
 // VolK8sConfigFromCompose returns a VolK8sConfig from a compose-go VolumeConfig
 // It extracts and infers values based on rules applied to the compose-go volume.
 func VolK8sConfigFromCompose(vol *composego.VolumeConfig) (VolK8sConfig, error) {
+	var (
+		k8sExt VolK8sConfig
+		err    error
+	)
 	cfg := DefaultVolK8sConfig()
-	volFromMap, err := ParseVolK8sConfigFromMap(vol.Extensions)
-	if err != nil {
-		return VolK8sConfig{}, err
+	if _, ok := vol.Extensions[K8SExtensionKey]; ok {
+		if k8sExt, err = ParseVolK8sConfigFromMap(vol.Extensions); err != nil {
+			return VolK8sConfig{}, err
+		}
 	}
 
-	cfg, err = cfg.Merge(volFromMap)
+	cfg, err = cfg.Merge(k8sExt)
 	if err != nil {
 		return VolK8sConfig{}, err
 	}
@@ -121,9 +126,14 @@ func VolK8sConfigFromCompose(vol *composego.VolumeConfig) (VolK8sConfig, error) 
 }
 
 // ParseVolK8sConfigFromMap parses a volume extension from the related map
-func ParseVolK8sConfigFromMap(m map[string]interface{}) (VolK8sConfig, error) {
+func ParseVolK8sConfigFromMap(m map[string]interface{}, opts ...K8sExtensionOption) (VolK8sConfig, error) {
+	var options extensionOptions
+	for _, o := range opts {
+		o(&options)
+	}
+
 	if _, ok := m[K8SExtensionKey]; !ok {
-		return VolK8sConfig{}, nil
+		return VolK8sConfig{}, fmt.Errorf("missing %s volume extension", K8SExtensionKey)
 	}
 
 	var ext VolumeExtension
@@ -135,6 +145,12 @@ func ParseVolK8sConfigFromMap(m map[string]interface{}) (VolK8sConfig, error) {
 
 	if err := yaml.NewDecoder(&buf).Decode(&ext); err != nil {
 		return VolK8sConfig{}, err
+	}
+
+	if !options.skipValidation {
+		if err := ext.K8S.Validate(); err != nil {
+			return VolK8sConfig{}, err
+		}
 	}
 
 	return ext.K8S, nil

--- a/pkg/kev/config/volextensions.go
+++ b/pkg/kev/config/volextensions.go
@@ -108,7 +108,7 @@ func VolK8sConfigFromCompose(vol *composego.VolumeConfig) (VolK8sConfig, error) 
 	)
 	cfg := DefaultVolK8sConfig()
 	if _, ok := vol.Extensions[K8SExtensionKey]; ok {
-		if k8sExt, err = ParseVolK8sConfigFromMap(vol.Extensions); err != nil {
+		if k8sExt, err = ParseVolK8sConfigFromMap(vol.Extensions, SkipValidation()); err != nil {
 			return VolK8sConfig{}, err
 		}
 	}

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1918,18 +1918,13 @@ var _ = Describe("Transform", func() {
 
 			When("readiness probe is not defined or disabled", func() {
 				JustBeforeEach(func() {
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(project.Extensions)
+					k8sSvc := config.SvcK8sConfig{}
+					k8sSvc.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
+					m, err := k8sSvc.ToMap()
+
 					Expect(err).NotTo(HaveOccurred())
 
-					k8sconf.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
-
-					m, err := k8sconf.ToMap()
-					Expect(err).NotTo(HaveOccurred())
-
-					projectService.Extensions = map[string]interface{}{
-						config.K8SExtensionKey: m,
-					}
-
+					projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
 					projectService, err = NewProjectService(projectService.ServiceConfig)
 				})
 

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -132,10 +132,10 @@ var _ = Describe("Transform", func() {
 
 		Context("with imaged pull secret specified via labels", func() {
 			BeforeEach(func() {
-				k8sconf := config.DefaultSvcK8sConfig()
-				k8sconf.Workload.ImagePull.Secret = "my-pp-secret"
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.ImagePull.Secret = "my-pp-secret"
 
-				m, err := k8sconf.ToMap()
+				m, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{
@@ -235,13 +235,11 @@ var _ = Describe("Transform", func() {
 			Context("and the config metadata points at external config", func() {
 				BeforeEach(func() {
 					project.Configs = composego.Configs{
-						configName: composego.ConfigObjConfig(
-							composego.ConfigObjConfig{
-								External: composego.External{
-									External: true,
-								},
+						configName: composego.ConfigObjConfig{
+							External: composego.External{
+								External: true,
 							},
-						),
+						},
 					}
 				})
 
@@ -472,11 +470,9 @@ var _ = Describe("Transform", func() {
 				mountPath = "/mount/path"
 
 				project.Configs = composego.Configs{
-					configName: composego.ConfigObjConfig(
-						composego.ConfigObjConfig{
-							File: "/path/to/config/file",
-						},
-					),
+					configName: composego.ConfigObjConfig{
+						File: "/path/to/config/file",
+					},
 				}
 
 				projectService.Configs = []composego.ServiceConfigObjConfig{
@@ -565,12 +561,12 @@ var _ = Describe("Transform", func() {
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: meta.ObjectMeta{
 							Annotations: configAnnotations(projectService),
-							Labels:      configLabels(projectService.Name), //added
+							Labels:      configLabels(projectService.Name), // added
 						},
 						Spec: expectedPodSpec,
 					},
-					ServiceName: projectService.Name, //added
-					UpdateStrategy: v1apps.StatefulSetUpdateStrategy{ //added
+					ServiceName: projectService.Name, // added
+					UpdateStrategy: v1apps.StatefulSetUpdateStrategy{ // added
 						Type:          v1apps.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &v1apps.RollingUpdateStatefulSetStrategy{},
 					},
@@ -603,11 +599,9 @@ var _ = Describe("Transform", func() {
 				mountPath = "/mount/path"
 
 				project.Configs = composego.Configs{
-					configName: composego.ConfigObjConfig(
-						composego.ConfigObjConfig{
-							File: "/path/to/config/file",
-						},
-					),
+					configName: composego.ConfigObjConfig{
+						File: "/path/to/config/file",
+					},
 				}
 
 				projectService.Configs = []composego.ServiceConfigObjConfig{
@@ -692,11 +686,9 @@ var _ = Describe("Transform", func() {
 				mountPath = "/mount/path"
 
 				project.Configs = composego.Configs{
-					configName: composego.ConfigObjConfig(
-						composego.ConfigObjConfig{
-							File: "/path/to/config/file",
-						},
-					),
+					configName: composego.ConfigObjConfig{
+						File: "/path/to/config/file",
+					},
 				}
 
 				projectService.Configs = []composego.ServiceConfigObjConfig{
@@ -1282,7 +1274,7 @@ var _ = Describe("Transform", func() {
 				Expect(p).To(Equal([]v1.ContainerPort{
 					{
 						ContainerPort: int32(8080),
-						Protocol:      v1.Protocol("TCP"),
+						Protocol:      "TCP",
 						HostIP:        "10.10.10.10",
 					},
 				}))
@@ -1741,7 +1733,7 @@ var _ = Describe("Transform", func() {
 			})
 
 			It("warns and continues", func() {
-				objects := []runtime.Object{}
+				var objects []runtime.Object
 				newObjs := k.createConfigMapFromComposeConfig(projectService, objects)
 				Expect(newObjs).To(HaveLen(0))
 			})
@@ -1757,7 +1749,7 @@ var _ = Describe("Transform", func() {
 			})
 
 			It("generates a ConfigMap object and appends it to objects slice", func() {
-				objects := []runtime.Object{}
+				var objects []runtime.Object
 				newObjs := k.createConfigMapFromComposeConfig(projectService, objects)
 				Expect(newObjs).To(HaveLen(1))
 			})
@@ -1776,7 +1768,7 @@ var _ = Describe("Transform", func() {
 				},
 				ObjectMeta: meta.ObjectMeta{
 					Name: networkName,
-					//Labels: ConfigLabels(name),
+					// Labels: ConfigLabels(name),
 				},
 				Spec: networking.NetworkPolicySpec{
 					PodSelector: meta.LabelSelector{
@@ -1896,12 +1888,12 @@ var _ = Describe("Transform", func() {
 
 			When("readiness probe is defined for project service", func() {
 				JustBeforeEach(func() {
-					k8sconf := config.DefaultSvcK8sConfig()
-					k8sconf.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
-					k8sconf.Workload.ReadinessProbe.Type = config.ProbeTypeExec.String()
-					k8sconf.Workload.ReadinessProbe.Exec.Command = []string{"hello world"}
+					svcK8sConfig := config.DefaultSvcK8sConfig()
+					svcK8sConfig.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
+					svcK8sConfig.Workload.ReadinessProbe.Type = config.ProbeTypeExec.String()
+					svcK8sConfig.Workload.ReadinessProbe.Exec.Command = []string{"hello world"}
 
-					ext, err := k8sconf.ToMap()
+					ext, err := svcK8sConfig.ToMap()
 					Expect(err).NotTo(HaveOccurred())
 					projectService.Extensions = map[string]interface{}{
 						config.K8SExtensionKey: ext,
@@ -1918,9 +1910,9 @@ var _ = Describe("Transform", func() {
 
 			When("readiness probe is not defined or disabled", func() {
 				JustBeforeEach(func() {
-					k8sSvc := config.SvcK8sConfig{}
-					k8sSvc.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
-					m, err := k8sSvc.ToMap()
+					svcK8sConfig := config.SvcK8sConfig{}
+					svcK8sConfig.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
+					m, err := svcK8sConfig.ToMap()
 
 					Expect(err).NotTo(HaveOccurred())
 
@@ -2016,10 +2008,10 @@ var _ = Describe("Transform", func() {
 
 		Context("with memory request provided in configuration", func() {
 			BeforeEach(func() {
-				k8sconf := config.DefaultSvcK8sConfig()
-				k8sconf.Workload.Resource.Memory = "10Mi"
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.Resource.Memory = "10Mi"
 
-				ext, err := k8sconf.ToMap()
+				ext, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2036,10 +2028,10 @@ var _ = Describe("Transform", func() {
 
 		Context("with memory limit provided in configuration", func() {
 			BeforeEach(func() {
-				k8sconf := config.DefaultSvcK8sConfig()
-				k8sconf.Workload.Resource.MaxMemory = "10M"
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.Resource.MaxMemory = "10M"
 
-				ext, err := k8sconf.ToMap()
+				ext, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2056,10 +2048,10 @@ var _ = Describe("Transform", func() {
 
 		Context("with cpu request provided in configuration", func() {
 			BeforeEach(func() {
-				k8sconf := config.DefaultSvcK8sConfig()
-				k8sconf.Workload.Resource.CPU = "0.1"
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.Resource.CPU = "0.1"
 
-				ext, err := k8sconf.ToMap()
+				ext, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2076,10 +2068,10 @@ var _ = Describe("Transform", func() {
 
 		Context("with cpu limit provided in configuration", func() {
 			BeforeEach(func() {
-				k8sconf := config.DefaultSvcK8sConfig()
-				k8sconf.Workload.Resource.MaxCPU = "0.5"
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.Resource.MaxCPU = "0.5"
 
-				ext, err := k8sconf.ToMap()
+				ext, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -203,12 +203,12 @@ func (e *Environment) loadOverride() (*Environment, error) {
 		services = append(services, serviceConfig)
 	}
 	volumes := Volumes{}
-	for _, v := range p.VolumeNames() {
-		volumeConfig, err := newVolumeConfig(v, p)
+	for _, volName := range p.VolumeNames() {
+		volumeConfig, err := newVolumeConfig(volName, p)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Cannot load environment [%s], volume [%s]", e.Name, v)
+			return nil, errors.Wrapf(err, "Cannot load environment [%s], volume [%s]", e.Name, volName)
 		}
-		volumes[v] = volumeConfig
+		volumes[volName] = volumeConfig
 	}
 	e.override = &composeOverride{
 		Version:  p.GetVersion(),

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -50,7 +50,9 @@ var _ = Describe("Reconcile", func() {
 		hook = testutil.NewLogger(logrus.DebugLevel)
 
 		r := kev.NewRenderRunner(workingDir, kev.WithUI(kmd.NoOpUI()))
-		r.LoadProject()
+		err = r.LoadProject()
+		Expect(err).NotTo(HaveOccurred(), workingDir)
+
 		manifest, mErr = r.Manifest().ReconcileConfig()
 		Expect(mErr).NotTo(HaveOccurred(), workingDir)
 
@@ -206,10 +208,10 @@ var _ = Describe("Reconcile", func() {
 				It("should not update the label in all environments", func() {
 					s, _ := env.GetService("wordpress")
 
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
+					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(k8sconf.Service.Type).To(Equal("LoadBalancer"))
+					Expect(svcK8sConfig.Service.Type).To(Equal("LoadBalancer"))
 				})
 
 				It("should log the change summary using the debug level", func() {

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -199,10 +199,10 @@ var _ = Describe("Reconcile", func() {
 				It("confirms the edit pre reconciliation", func() {
 					s, _ := override.GetService("wordpress")
 
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
+					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(k8sconf.Service.Type).To(Equal("LoadBalancer"))
+					Expect(svcK8sConfig.Service.Type).To(Equal("LoadBalancer"))
 				})
 
 				It("should not update the label in all environments", func() {
@@ -521,12 +521,12 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should have a valid tcp", func() {
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(env.GetServices()[0].Extensions)
+					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(env.GetServices()[0].Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(k8sconf.Workload.LivenessProbe.Type).To(Equal(config.ProbeTypeTCP.String()))
-					Expect(k8sconf.Workload.LivenessProbe.TCP.Port).To(Equal(8080))
-					Expect(k8sconf.Workload.LivenessProbe.Exec.Command).To(BeEmpty())
+					Expect(svcK8sConfig.Workload.LivenessProbe.Type).To(Equal(config.ProbeTypeTCP.String()))
+					Expect(svcK8sConfig.Workload.LivenessProbe.TCP.Port).To(Equal(8080))
+					Expect(svcK8sConfig.Workload.LivenessProbe.Exec.Command).To(BeEmpty())
 				})
 			})
 			Context("liveness and readiness http", func() {
@@ -539,24 +539,24 @@ var _ = Describe("Reconcile", func() {
 					svcCfg, err := env.GetService("db")
 					Expect(err).NotTo(HaveOccurred())
 
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(svcCfg.Extensions)
+					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(svcCfg.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(k8sconf.Workload.LivenessProbe.Type).To(Equal(config.ProbeTypeHTTP.String()))
-					Expect(k8sconf.Workload.LivenessProbe.HTTP.Port).To(Equal(8080))
-					Expect(k8sconf.Workload.LivenessProbe.HTTP.Path).To(Equal("/status"))
-					Expect(k8sconf.Workload.LivenessProbe.Exec.Command).To(BeEmpty())
+					Expect(svcK8sConfig.Workload.LivenessProbe.Type).To(Equal(config.ProbeTypeHTTP.String()))
+					Expect(svcK8sConfig.Workload.LivenessProbe.HTTP.Port).To(Equal(8080))
+					Expect(svcK8sConfig.Workload.LivenessProbe.HTTP.Path).To(Equal("/status"))
+					Expect(svcK8sConfig.Workload.LivenessProbe.Exec.Command).To(BeEmpty())
 				})
 
 				It("should have a valid http readiness probe", func() {
 					svcCfg, err := env.GetService("wordpress")
 					Expect(err).NotTo(HaveOccurred())
 
-					k8sconf, err := config.ParseSvcK8sConfigFromMap(svcCfg.Extensions)
+					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(svcCfg.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(k8sconf.Workload.ReadinessProbe.Type).To(Equal(config.ProbeTypeHTTP.String()))
-					Expect(k8sconf.Workload.ReadinessProbe.HTTP.Port).To(Equal(8080))
+					Expect(svcK8sConfig.Workload.ReadinessProbe.Type).To(Equal(config.ProbeTypeHTTP.String()))
+					Expect(svcK8sConfig.Workload.ReadinessProbe.HTTP.Port).To(Equal(8080))
 				})
 			})
 		})

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -186,7 +186,7 @@ func (m *Manifest) ReconcileConfig(envs ...string) (*Manifest, error) {
 	}
 
 	for _, e := range filteredEnvs {
-		if err := validateExtensions(e.override.Services); err != nil {
+		if err := validateExtensions(e.override); err != nil {
 			sg := m.UI.StepGroup()
 			defer sg.Done()
 			renderStepError(m.UI, sg.Add(""), renderStepReconcile, err)
@@ -205,14 +205,19 @@ func (m *Manifest) ReconcileConfig(envs ...string) (*Manifest, error) {
 	return m, nil
 }
 
-func validateExtensions(services Services) error {
-	for _, s := range services {
+func validateExtensions(override *composeOverride) error {
+	for _, s := range override.Services {
 		_, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 		if err != nil {
 			return errors.Wrapf(err, "when parsing service %s extensions", s.Name)
 		}
 	}
-
+	for name, vol := range override.Volumes {
+		_, err := config.ParseVolK8sConfigFromMap(vol.Extensions)
+		if err != nil {
+			return errors.Wrapf(err, "when parsing vol %s extensions", name)
+		}
+	}
 	return nil
 }
 

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -207,9 +207,9 @@ func (m *Manifest) ReconcileConfig(envs ...string) (*Manifest, error) {
 
 func validateExtensions(services Services) error {
 	for _, s := range services {
-		_, err := config.ParseSvcK8sConfigFromMap(s.Extensions, config.RequireExtensions())
+		_, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 		if err != nil {
-			return errors.Wrapf(err, "%s extensions not valid for service %s", config.K8SExtensionKey, s.Name)
+			return errors.Wrapf(err, "when parsing service %s extensions", s.Name)
 		}
 	}
 

--- a/pkg/kev/testdata/reconcile-env-var-override/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-override/docker-compose.kev.dev.yaml
@@ -31,3 +31,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-env-var-removal/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-removal/docker-compose.kev.dev.yaml
@@ -57,4 +57,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
-
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.kev.dev.yaml
@@ -31,3 +31,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-healthcheck-http/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-healthcheck-http/docker-compose.kev.dev.yaml
@@ -54,3 +54,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-healthcheck-tcp/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-healthcheck-tcp/docker-compose.kev.dev.yaml
@@ -27,3 +27,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-override-keep/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-override-keep/docker-compose.kev.dev.yaml
@@ -28,3 +28,6 @@ volumes:
     labels:
       kev.volume.size: 200Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-override-rollback/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-override-rollback/docker-compose.kev.dev.yaml
@@ -29,3 +29,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-basic/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/docker-compose.kev.dev.yaml
@@ -29,3 +29,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-deploy/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-deploy/docker-compose.kev.dev.yaml
@@ -29,3 +29,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-edit/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-edit/docker-compose.kev.dev.yaml
@@ -53,3 +53,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-healthcheck/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-healthcheck/docker-compose.kev.dev.yaml
@@ -23,3 +23,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-removal/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-removal/docker-compose.kev.dev.yaml
@@ -54,3 +54,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-version/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-version/docker-compose.kev.dev.yaml
@@ -29,3 +29,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-volume-edit/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-edit/docker-compose.kev.dev.yaml
@@ -53,3 +53,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-volume-removal/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-removal/docker-compose.kev.dev.yaml
@@ -53,3 +53,6 @@ volumes:
     labels:
       kev.volume.size: 100Mi
       kev.volume.storage-class: standard
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/volumes.go
+++ b/pkg/kev/volumes.go
@@ -25,7 +25,8 @@ import (
 
 func newVolumeConfig(name string, p *ComposeProject) (VolumeConfig, error) {
 	cfg := VolumeConfig{
-		Labels: p.Volumes[name].Labels,
+		Labels:     p.Volumes[name].Labels,
+		Extensions: p.Volumes[name].Extensions,
 	}
 	return cfg, cfg.validate()
 }


### PR DESCRIPTION
Resolves #488 

- Ensures reconciliation loads volumes with extensions.
- Removes redundant reconciliation patch for service k8s extension value edits.
- Adds volume validation to the reconciliation process (similar to services).
- Extra tidy and test fixture updates.
