### PR TITLE
Move the pod-security labels to extensions.

### DIFF
--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -45,13 +45,13 @@ const (
 	DefaultImagePullSecret = ""
 
 	// DefaultSecurityContextRunAsUser default UID for pod security context
-	DefaultSecurityContextRunAsUser = ""
+	DefaultSecurityContextRunAsUser = 0
 
 	// DefaultSecurityContextRunAsGroup default GID for pod security context
-	DefaultSecurityContextRunAsGroup = ""
+	DefaultSecurityContextRunAsGroup = 0
 
 	// DefaultSecurityContextFsGroup default fs Group for pod security context
-	DefaultSecurityContextFsGroup = ""
+	DefaultSecurityContextFsGroup = 0
 
 	// NoService default value
 	NoService = "None"

--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -44,15 +44,6 @@ const (
 	// DefaultImagePullSecret default image pull credentials secret name
 	DefaultImagePullSecret = ""
 
-	// DefaultSecurityContextRunAsUser default UID for pod security context
-	DefaultSecurityContextRunAsUser = 0
-
-	// DefaultSecurityContextRunAsGroup default GID for pod security context
-	DefaultSecurityContextRunAsGroup = 0
-
-	// DefaultSecurityContextFsGroup default fs Group for pod security context
-	DefaultSecurityContextFsGroup = 0
-
 	// NoService default value
 	NoService = "None"
 
@@ -143,5 +134,16 @@ const (
 	DefaultProbeDisable = false
 )
 
-// DefaultLivenessProbeCommand default command
-var DefaultLivenessProbeCommand = []string{"echo", "Define healthcheck command for service"}
+var (
+	// DefaultSecurityContextRunAsUser default UID for pod security context
+	DefaultSecurityContextRunAsUser *int64 = nil
+
+	// DefaultSecurityContextRunAsGroup default GID for pod security context
+	DefaultSecurityContextRunAsGroup *int64 = nil
+
+	// DefaultSecurityContextFsGroup default fs Group for pod security context
+	DefaultSecurityContextFsGroup *int64 = nil
+
+	// DefaultLivenessProbeCommand default command
+	DefaultLivenessProbeCommand = []string{"echo", "Define healthcheck command for service"}
+)

--- a/pkg/kev/config/labels.go
+++ b/pkg/kev/config/labels.go
@@ -22,15 +22,6 @@ const (
 	// LabelWorkloadRollingUpdateMaxSurge max number of nodes updated at once
 	LabelWorkloadRollingUpdateMaxSurge = LabelPrefix + "workload.rolling-update-max-surge"
 
-	// LabelWorkloadSecurityContextRunAsUser sets pod security context RunAsUser attribute
-	LabelWorkloadSecurityContextRunAsUser = LabelPrefix + "workload.pod-security-run-as-user"
-
-	// LabelWorkloadSecurityContextRunAsGroup sets pod security context RunAsGroup attribute
-	LabelWorkloadSecurityContextRunAsGroup = LabelPrefix + "workload.pod-security-run-as-group"
-
-	// LabelWorkloadSecurityContextFsGroup sets pod security context FsGroup attribute
-	LabelWorkloadSecurityContextFsGroup = LabelPrefix + "workload.pod-security-fs-group"
-
 	// LabelWorkloadServiceAccountName defines service account name to be used by the workload
 	LabelWorkloadServiceAccountName = LabelPrefix + "workload.service-account-name"
 
@@ -44,4 +35,4 @@ const (
 	LabelServiceExposeTLSSecret = LabelPrefix + "service.expose.tls-secret"
 )
 
-var BaseServiceLabels = []string{}
+var BaseServiceLabels []string

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -428,9 +428,9 @@ type Autoscale struct {
 }
 
 type PodSecurity struct {
-	RunAsUser  int `yaml:"runAsUser,omitempty"`
-	RunAsGroup int `yaml:"runAsGroup,omitempty"`
-	FsGroup    int `yaml:"fsGroup,omitempty"`
+	RunAsUser  *int64 `yaml:"runAsUser,omitempty"`
+	RunAsGroup *int64 `yaml:"runAsGroup,omitempty"`
+	FsGroup    *int64 `yaml:"fsGroup,omitempty"`
 }
 
 // Service will hold the service specific extensions in the future.

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -100,7 +100,8 @@ func DefaultSvcK8sConfig() SvcK8sConfig {
 			ImagePull: ImagePull{
 				Policy: DefaultImagePullPolicy,
 			},
-			Autoscale: AutoscaleWithDefaults(),
+			Autoscale:   AutoscaleWithDefaults(),
+			PodSecurity: PodSecurityWithDefaults(),
 		},
 		Service: Service{
 			Type: "None",
@@ -137,6 +138,7 @@ func SvcK8sConfigFromCompose(svc *composego.ServiceConfig) (SvcK8sConfig, error)
 
 	cfg.Workload.Resource = svcResource
 	cfg.Workload.Autoscale = AutoscaleWithDefaults()
+	cfg.Workload.PodSecurity = PodSecurityWithDefaults()
 
 	if _, ok := svc.Extensions[K8SExtensionKey]; ok {
 		if k8sExt, err = ParseSvcK8sConfigFromMap(svc.Extensions, SkipValidation()); err != nil {
@@ -221,6 +223,14 @@ func AutoscaleWithDefaults() Autoscale {
 		MaxReplicas:     DefaultAutoscaleMaxReplicaNumber,
 		CPUThreshold:    DefaultAutoscaleCPUThreshold,
 		MemoryThreshold: DefaultAutoscaleMemoryThreshold,
+	}
+}
+
+func PodSecurityWithDefaults() PodSecurity {
+	return PodSecurity{
+		RunAsUser:  DefaultSecurityContextRunAsUser,
+		RunAsGroup: DefaultSecurityContextRunAsGroup,
+		FsGroup:    DefaultSecurityContextFsGroup,
 	}
 }
 
@@ -396,6 +406,7 @@ type Workload struct {
 	ImagePull      ImagePull      `yaml:"imagePull,omitempty"`
 	Resource       Resource       `yaml:"resource,omitempty"`
 	Autoscale      Autoscale      `yaml:"autoscale,omitempty"`
+	PodSecurity    PodSecurity    `yaml:"podSecurity,omitempty"`
 }
 
 type Resource struct {
@@ -414,6 +425,12 @@ type Autoscale struct {
 	MaxReplicas     int `yaml:"maxReplicas,omitempty"`
 	CPUThreshold    int `yaml:"cpuThreshold,omitempty"`
 	MemoryThreshold int `yaml:"memThreshold,omitempty"`
+}
+
+type PodSecurity struct {
+	RunAsUser  int `yaml:"runAsUser,omitempty"`
+	RunAsGroup int `yaml:"runAsGroup,omitempty"`
+	FsGroup    int `yaml:"fsGroup,omitempty"`
 }
 
 // Service will hold the service specific extensions in the future.

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -279,30 +279,18 @@ func (p *ProjectService) resourceLimits() (*int64, *int64) {
 }
 
 // runAsUser returns pod security context runAsUser value
-func (p *ProjectService) runAsUser() string {
-	if val, ok := p.Labels[config.LabelWorkloadSecurityContextRunAsUser]; ok {
-		return val
-	}
-
-	return config.DefaultSecurityContextRunAsUser
+func (p *ProjectService) runAsUser() int64 {
+	return int64(p.SvcK8sConfig.Workload.PodSecurity.RunAsUser)
 }
 
 // runAsGroup returns pod security context runAsGroup value
-func (p *ProjectService) runAsGroup() string {
-	if val, ok := p.Labels[config.LabelWorkloadSecurityContextRunAsGroup]; ok {
-		return val
-	}
-
-	return config.DefaultSecurityContextRunAsGroup
+func (p *ProjectService) runAsGroup() int64 {
+	return int64(p.SvcK8sConfig.Workload.PodSecurity.RunAsGroup)
 }
 
 // fsGroup returns pod security context fsGroup value
-func (p *ProjectService) fsGroup() string {
-	if val, ok := p.Labels[config.LabelWorkloadSecurityContextFsGroup]; ok {
-		return val
-	}
-
-	return config.DefaultSecurityContextFsGroup
+func (p *ProjectService) fsGroup() int64 {
+	return int64(p.SvcK8sConfig.Workload.PodSecurity.FsGroup)
 }
 
 // imagePullPolicy returns image PullPolicy for project service

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -279,18 +279,18 @@ func (p *ProjectService) resourceLimits() (*int64, *int64) {
 }
 
 // runAsUser returns pod security context runAsUser value
-func (p *ProjectService) runAsUser() int64 {
-	return int64(p.SvcK8sConfig.Workload.PodSecurity.RunAsUser)
+func (p *ProjectService) runAsUser() *int64 {
+	return p.SvcK8sConfig.Workload.PodSecurity.RunAsUser
 }
 
 // runAsGroup returns pod security context runAsGroup value
-func (p *ProjectService) runAsGroup() int64 {
-	return int64(p.SvcK8sConfig.Workload.PodSecurity.RunAsGroup)
+func (p *ProjectService) runAsGroup() *int64 {
+	return p.SvcK8sConfig.Workload.PodSecurity.RunAsGroup
 }
 
 // fsGroup returns pod security context fsGroup value
-func (p *ProjectService) fsGroup() int64 {
-	return int64(p.SvcK8sConfig.Workload.PodSecurity.FsGroup)
+func (p *ProjectService) fsGroup() *int64 {
+	return p.SvcK8sConfig.Workload.PodSecurity.FsGroup
 }
 
 // imagePullPolicy returns image PullPolicy for project service

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -760,20 +760,21 @@ var _ = Describe("ProjectService", func() {
 	Describe("runAsUser", func() {
 
 		Context("when defined via an extension", func() {
-			runAsUser := 1000
+			runAsUser := int64(1000)
 
 			BeforeEach(func() {
-				svcK8sConfig.Workload.PodSecurity.RunAsUser = runAsUser
+				svcK8sConfig.Workload.PodSecurity.RunAsUser = &runAsUser
 			})
 
 			It("returns the extension value", func() {
-				Expect(projectService.runAsUser()).To(Equal(int64(runAsUser)))
+				expected := runAsUser
+				Expect(projectService.runAsUser()).To(Equal(&expected))
 			})
 		})
 
 		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.runAsUser()).To(Equal(int64(config.DefaultSecurityContextRunAsUser)))
+				Expect(projectService.runAsUser()).To(Equal(config.DefaultSecurityContextRunAsUser))
 			})
 		})
 	})
@@ -781,20 +782,21 @@ var _ = Describe("ProjectService", func() {
 	Describe("runAsGroup", func() {
 
 		Context("when defined via an extension", func() {
-			runAsGroup := 1000
+			runAsGroup := int64(1000)
 
 			BeforeEach(func() {
-				svcK8sConfig.Workload.PodSecurity.RunAsGroup = runAsGroup
+				svcK8sConfig.Workload.PodSecurity.RunAsGroup = &runAsGroup
 			})
 
 			It("returns the extension value", func() {
-				Expect(projectService.runAsGroup()).To(Equal(int64(runAsGroup)))
+				expected := runAsGroup
+				Expect(projectService.runAsGroup()).To(Equal(&expected))
 			})
 		})
 
 		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.runAsGroup()).To(Equal(int64(config.DefaultSecurityContextRunAsGroup)))
+				Expect(projectService.runAsGroup()).To(Equal(config.DefaultSecurityContextRunAsGroup))
 			})
 		})
 	})
@@ -802,20 +804,21 @@ var _ = Describe("ProjectService", func() {
 	Describe("fsGroup", func() {
 
 		Context("when defined via an extension", func() {
-			fsGroup := 1000
+			fsGroup := int64(1000)
 
 			BeforeEach(func() {
-				svcK8sConfig.Workload.PodSecurity.FsGroup = fsGroup
+				svcK8sConfig.Workload.PodSecurity.FsGroup = &fsGroup
 			})
 
 			It("returns the extension value", func() {
-				Expect(projectService.fsGroup()).To(Equal(int64(fsGroup)))
+				expected := fsGroup
+				Expect(projectService.fsGroup()).To(Equal(&expected))
 			})
 		})
 
 		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.fsGroup()).To(Equal(int64(config.DefaultSecurityContextFsGroup)))
+				Expect(projectService.fsGroup()).To(Equal(config.DefaultSecurityContextFsGroup))
 			})
 		})
 	})

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -759,69 +759,63 @@ var _ = Describe("ProjectService", func() {
 
 	Describe("runAsUser", func() {
 
-		Context("when defined via labels", func() {
-			runAsUser := "1000"
+		Context("when defined via an extension", func() {
+			runAsUser := 1000
 
 			BeforeEach(func() {
-				labels = composego.Labels{
-					config.LabelWorkloadSecurityContextRunAsUser: runAsUser,
-				}
+				svcK8sConfig.Workload.PodSecurity.RunAsUser = runAsUser
 			})
 
-			It("returns label value", func() {
-				Expect(projectService.runAsUser()).To(Equal(runAsUser))
+			It("returns the extension value", func() {
+				Expect(projectService.runAsUser()).To(Equal(int64(runAsUser)))
 			})
 		})
 
-		Context("when not defined via labels", func() {
+		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.runAsUser()).To(Equal(config.DefaultSecurityContextRunAsUser))
+				Expect(projectService.runAsUser()).To(Equal(int64(config.DefaultSecurityContextRunAsUser)))
 			})
 		})
 	})
 
 	Describe("runAsGroup", func() {
 
-		Context("when defined via labels", func() {
-			runAsGroup := "1000"
+		Context("when defined via an extension", func() {
+			runAsGroup := 1000
 
 			BeforeEach(func() {
-				labels = composego.Labels{
-					config.LabelWorkloadSecurityContextRunAsGroup: runAsGroup,
-				}
+				svcK8sConfig.Workload.PodSecurity.RunAsGroup = runAsGroup
 			})
 
-			It("returns label value", func() {
-				Expect(projectService.runAsGroup()).To(Equal(runAsGroup))
+			It("returns the extension value", func() {
+				Expect(projectService.runAsGroup()).To(Equal(int64(runAsGroup)))
 			})
 		})
 
-		Context("when not defined via labels", func() {
+		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.runAsGroup()).To(Equal(config.DefaultSecurityContextRunAsGroup))
+				Expect(projectService.runAsGroup()).To(Equal(int64(config.DefaultSecurityContextRunAsGroup)))
 			})
 		})
 	})
 
 	Describe("fsGroup", func() {
 
-		Context("when defined via labels", func() {
-			fsGroup := "1000"
+		Context("when defined via an extension", func() {
+			fsGroup := 1000
 
 			BeforeEach(func() {
-				labels = composego.Labels{
-					config.LabelWorkloadSecurityContextFsGroup: fsGroup,
-				}
+				svcK8sConfig.Workload.PodSecurity.FsGroup = fsGroup
 			})
 
-			It("returns label value", func() {
-				Expect(projectService.fsGroup()).To(Equal(fsGroup))
+			It("returns the extension value", func() {
+				Expect(projectService.fsGroup()).To(Equal(int64(fsGroup)))
 			})
 		})
 
-		Context("when not defined via labels", func() {
+		Context("when not defined via an extension", func() {
 			It("returns default value", func() {
-				Expect(projectService.fsGroup()).To(Equal(config.DefaultSecurityContextFsGroup))
+				Expect(projectService.fsGroup()).To(Equal(int64(config.DefaultSecurityContextFsGroup)))
 			})
 		})
 	})

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1900,16 +1900,13 @@ func (k *Kubernetes) setPodResources(projectService ProjectService, template *v1
 // setPodSecurityContext sets a pod security context
 func (k *Kubernetes) setPodSecurityContext(projectService ProjectService, podSecurityContext *v1.PodSecurityContext) {
 	// @step set RunAsUser
-	runAsUser := projectService.runAsUser()
-	podSecurityContext.RunAsUser = &runAsUser
+	podSecurityContext.RunAsUser = projectService.runAsUser()
 
 	// @step set RunAsGroup
-	runAsGroup := projectService.runAsGroup()
-	podSecurityContext.RunAsGroup = &runAsGroup
+	podSecurityContext.RunAsGroup = projectService.runAsGroup()
 
 	// @step set FsGroup
-	fsGroup := projectService.fsGroup()
-	podSecurityContext.FSGroup = &fsGroup
+	podSecurityContext.FSGroup = projectService.fsGroup()
 
 	// @step set supplementalGroups
 	if projectService.GroupAdd != nil {

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -787,12 +787,12 @@ func (k *Kubernetes) initHpa(projectService ProjectService, target runtime.Objec
 // @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/kubernetes.go#L502
 func (k *Kubernetes) createSecrets() ([]*v1.Secret, error) {
 	var objects []*v1.Secret
-	for name, config := range k.Project.Secrets {
-		if config.File != "" {
-			dataString, err := getContentFromFile(config.File)
+	for name, secretConfig := range k.Project.Secrets {
+		if secretConfig.File != "" {
+			dataString, err := getContentFromFile(secretConfig.File)
 			if err != nil {
 				log.ErrorWithFields(log.Fields{
-					"file": config.File,
+					"file": secretConfig.File,
 				}, "Unable to read secret(s) from file")
 
 				return nil, err
@@ -1513,7 +1513,7 @@ func (k *Kubernetes) initPod(projectService ProjectService) *v1.Pod {
 
 // createNetworkPolicy initializes Network policy
 // @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/kubernetes/kubernetes.go#L1109
-func (k *Kubernetes) createNetworkPolicy(projectServiceName string, networkName string) (*networking.NetworkPolicy, error) {
+func (k *Kubernetes) createNetworkPolicy(_, networkName string) (*networking.NetworkPolicy, error) {
 	str := "true"
 
 	np := &networking.NetworkPolicy{
@@ -1901,30 +1901,15 @@ func (k *Kubernetes) setPodResources(projectService ProjectService, template *v1
 func (k *Kubernetes) setPodSecurityContext(projectService ProjectService, podSecurityContext *v1.PodSecurityContext) {
 	// @step set RunAsUser
 	runAsUser := projectService.runAsUser()
-	if runAsUser != "" {
-		if i, err := strconv.Atoi(runAsUser); err == nil {
-			v := int64(i)
-			podSecurityContext.RunAsUser = &v
-		}
-	}
+	podSecurityContext.RunAsUser = &runAsUser
 
 	// @step set RunAsGroup
 	runAsGroup := projectService.runAsGroup()
-	if runAsGroup != "" {
-		if i, err := strconv.Atoi(runAsGroup); err == nil {
-			v := int64(i)
-			podSecurityContext.RunAsGroup = &v
-		}
-	}
+	podSecurityContext.RunAsGroup = &runAsGroup
 
 	// @step set FsGroup
 	fsGroup := projectService.fsGroup()
-	if fsGroup != "" {
-		if i, err := strconv.Atoi(fsGroup); err == nil {
-			v := int64(i)
-			podSecurityContext.FSGroup = &v
-		}
-	}
+	podSecurityContext.FSGroup = &fsGroup
 
 	// @step set supplementalGroups
 	if projectService.GroupAdd != nil {

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -2080,7 +2080,7 @@ var _ = Describe("Transform", func() {
 
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodSecurity.RunAsUser = int(runAsUser)
+				svcK8sConfig.Workload.PodSecurity.RunAsUser = &runAsUser
 
 				m, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
@@ -2102,7 +2102,7 @@ var _ = Describe("Transform", func() {
 
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodSecurity.RunAsGroup = int(runAsGroup)
+				svcK8sConfig.Workload.PodSecurity.RunAsGroup = &runAsGroup
 
 				m, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())
@@ -2124,7 +2124,7 @@ var _ = Describe("Transform", func() {
 
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodSecurity.FsGroup = int(fsGroup)
+				svcK8sConfig.Workload.PodSecurity.FsGroup = &fsGroup
 
 				m, err := svcK8sConfig.ToMap()
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -2075,13 +2075,20 @@ var _ = Describe("Transform", func() {
 	Describe("setPodSecurityContext", func() {
 		podSecContext := &v1.PodSecurityContext{}
 
-		When("runAsUser label is specified", func() {
+		When("runAsUser is specified in a k8s extension", func() {
 			runAsUser := int64(1000)
 
 			BeforeEach(func() {
-				projectService.Labels = composego.Labels{
-					config.LabelWorkloadSecurityContextRunAsUser: strconv.Itoa(int(runAsUser)),
-				}
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.PodSecurity.RunAsUser = int(runAsUser)
+
+				m, err := svcK8sConfig.ToMap()
+				Expect(err).NotTo(HaveOccurred())
+
+				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
+
+				projectService, err = NewProjectService(projectService.ServiceConfig)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("adds RunAsUser into pod security context as expected", func() {
@@ -2090,13 +2097,20 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("runAsGroup label is specified", func() {
+		When("runAsGroup is specified in a k8s extension", func() {
 			runAsGroup := int64(1000)
 
 			BeforeEach(func() {
-				projectService.Labels = composego.Labels{
-					config.LabelWorkloadSecurityContextRunAsGroup: strconv.Itoa(int(runAsGroup)),
-				}
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.PodSecurity.RunAsGroup = int(runAsGroup)
+
+				m, err := svcK8sConfig.ToMap()
+				Expect(err).NotTo(HaveOccurred())
+
+				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
+
+				projectService, err = NewProjectService(projectService.ServiceConfig)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("adds RunAsGroup into pod security context as expected", func() {
@@ -2105,13 +2119,20 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("fsGroup label is specified", func() {
+		When("fsGroup is specified in a k8s extension", func() {
 			fsGroup := int64(1000)
 
 			BeforeEach(func() {
-				projectService.Labels = composego.Labels{
-					config.LabelWorkloadSecurityContextFsGroup: strconv.Itoa(int(fsGroup)),
-				}
+				svcK8sConfig := config.DefaultSvcK8sConfig()
+				svcK8sConfig.Workload.PodSecurity.FsGroup = int(fsGroup)
+
+				m, err := svcK8sConfig.ToMap()
+				Expect(err).NotTo(HaveOccurred())
+
+				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
+
+				projectService, err = NewProjectService(projectService.ServiceConfig)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("adds FSGroup into pod security context as expected", func() {


### PR DESCRIPTION
Resolves #515 

- Adds PodSecurity to the extension Workload.
- Changes defaults from `string` to `*int64`s.
- Fixes tests and tidy up.
