### PR TITLE
Turn Restart Policy string value sets into enums

### DIFF
--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -59,14 +59,14 @@ const (
 	// HeadlessService svc type
 	HeadlessService = "Headless"
 
-	// RestartPolicyAlways default value
-	RestartPolicyAlways = "Always"
-
-	// RestartPolicyOnFailure restart policy
-	RestartPolicyOnFailure = "OnFailure"
-
-	// RestartPolicyNever restart policy
-	RestartPolicyNever = "Never"
+	// // RestartPolicyAlways default value
+	// RestartPolicyAlways = "Always"
+	//
+	// // RestartPolicyOnFailure restart policy
+	// RestartPolicyOnFailure = "OnFailure"
+	//
+	// // RestartPolicyNever restart policy
+	// RestartPolicyNever = "Never"
 
 	// DeploymentWorkload workload type
 	DeploymentWorkload = "Deployment"

--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -59,15 +59,6 @@ const (
 	// HeadlessService svc type
 	HeadlessService = "Headless"
 
-	// // RestartPolicyAlways default value
-	// RestartPolicyAlways = "Always"
-	//
-	// // RestartPolicyOnFailure restart policy
-	// RestartPolicyOnFailure = "OnFailure"
-	//
-	// // RestartPolicyNever restart policy
-	// RestartPolicyNever = "Never"
-
 	// DeploymentWorkload workload type
 	DeploymentWorkload = "Deployment"
 

--- a/pkg/kev/config/probes.go
+++ b/pkg/kev/config/probes.go
@@ -71,10 +71,10 @@ func DefaultLivenessProbe() LivenessProbe {
 			Exec: ExecProbe{
 				Command: DefaultLivenessProbeCommand,
 			},
-			InitialDelay:      delay,
-			Period:            interval,
-			FailureThreashold: DefaultProbeRetries,
-			Timeout:           timeout,
+			InitialDelay:     delay,
+			Period:           interval,
+			FailureThreshold: DefaultProbeRetries,
+			Timeout:          timeout,
 		},
 	}
 }
@@ -95,10 +95,10 @@ func DefaultReadinessProbe() ReadinessProbe {
 	return ReadinessProbe{
 		Type: ProbeTypeNone.String(),
 		ProbeConfig: ProbeConfig{
-			InitialDelay:      delay,
-			Period:            interval,
-			FailureThreashold: DefaultProbeRetries,
-			Timeout:           timeout,
+			InitialDelay:     delay,
+			Period:           interval,
+			FailureThreshold: DefaultProbeRetries,
+			Timeout:          timeout,
 		},
 	}
 }
@@ -109,10 +109,10 @@ type ProbeConfig struct {
 	TCP  TCPProbe  `yaml:"tcp,omitempty"`
 	Exec ExecProbe `yaml:"exec,omitempty"`
 
-	InitialDelay      time.Duration `yaml:"initialDelay,omitempty"`
-	Period            time.Duration `yaml:"period,omitempty"`
-	FailureThreashold int           `yaml:"failureThreashold,omitempty"`
-	Timeout           time.Duration `yaml:"timeout,omitempty"`
+	InitialDelay     time.Duration `yaml:"initialDelay,omitempty"`
+	Period           time.Duration `yaml:"period,omitempty"`
+	FailureThreshold int           `yaml:"failureThreshold,omitempty"`
+	Timeout          time.Duration `yaml:"timeout,omitempty"`
 }
 
 // HTTPProbe holds the necessary properties to define the http check on the k8s probe.

--- a/pkg/kev/config/restart.go
+++ b/pkg/kev/config/restart.go
@@ -76,6 +76,6 @@ func inferRestartPolicyFromComposeValue(v string) RestartPolicy {
 	case "unless-stopped":
 		return RestartPolicyAlways
 	default:
-		return ""
+		return RestartPolicyAlways
 	}
 }

--- a/pkg/kev/config/restart.go
+++ b/pkg/kev/config/restart.go
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2021 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+type RestartPolicy string
+
+const (
+	// RestartPolicyAlways default value
+	RestartPolicyAlways RestartPolicy = "Always"
+
+	// RestartPolicyOnFailure restart policy
+	RestartPolicyOnFailure RestartPolicy = "OnFailure"
+
+	// RestartPolicyNever restart policy
+	RestartPolicyNever RestartPolicy = "Never"
+)
+
+// String converts a restart policy to a string value
+func (p RestartPolicy) String() string {
+	return string(p)
+}
+
+// restartPolicies are the only restart policy settings
+var restartPolicies = map[RestartPolicy]bool{
+	RestartPolicyAlways:    true,
+	RestartPolicyOnFailure: true,
+	RestartPolicyNever:     true,
+}
+
+// RestartPoliciesFromValue returns a Restart Policy for a given case insensitive value.
+// Returns a blank string and false for unknown values.
+func RestartPoliciesFromValue(s string) (RestartPolicy, bool) {
+	for k, v := range restartPolicies {
+		if strings.ToLower(k.String()) == strings.ToLower(s) {
+			return k, v
+		}
+	}
+	return "", false
+}
+
+// validateRestartPolicy validator to validate a restart policy
+func validateRestartPolicy(fl validator.FieldLevel) bool {
+	_, valid := RestartPoliciesFromValue(fl.Field().String())
+	return valid
+}
+
+// inferRestartPolicyFromComposeValue infers a Restart Policy for a compose value
+func inferRestartPolicyFromComposeValue(v string) RestartPolicy {
+	switch strings.ToLower(v) {
+	case "", "always", "any":
+		return RestartPolicyAlways
+	case "no", "none", "never":
+		return RestartPolicyNever
+	case "on-failure", "onfailure":
+		return RestartPolicyOnFailure
+	case "unless-stopped":
+		return RestartPolicyAlways
+	default:
+		return ""
+	}
+}

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -434,12 +434,11 @@ type Workload struct {
 	RollingUpdateMaxSurge int            `yaml:"rollingUpdateMaxSurge" validate:""`
 	LivenessProbe         LivenessProbe  `yaml:"livenessProbe" validate:"required"`
 	ReadinessProbe        ReadinessProbe `yaml:"readinessProbe,omitempty"`
-	// RestartPolicy  string         `yaml:"restartPolicy,omitempty"`
-	RestartPolicy RestartPolicy `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`
-	ImagePull     ImagePull     `yaml:"imagePull,omitempty"`
-	Resource      Resource      `yaml:"resource,omitempty"`
-	Autoscale     Autoscale     `yaml:"autoscale,omitempty"`
-	PodSecurity   PodSecurity   `yaml:"podSecurity,omitempty"`
+	RestartPolicy         RestartPolicy  `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`
+	ImagePull             ImagePull      `yaml:"imagePull,omitempty"`
+	Resource              Resource       `yaml:"resource,omitempty"`
+	Autoscale             Autoscale      `yaml:"autoscale,omitempty"`
+	PodSecurity           PodSecurity    `yaml:"podSecurity,omitempty"`
 }
 
 type Resource struct {

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -305,17 +305,17 @@ func getServiceType(serviceType string) (string, error) {
 
 // WorkloadRestartPolicyFromCompose infers a kev-valid restart policy from compose data.
 func WorkloadRestartPolicyFromCompose(svc *composego.ServiceConfig) RestartPolicy {
-	switch {
-	case svc.Restart != "": // docker-compose v2
-		if p := inferRestartPolicyFromComposeValue(svc.Restart); p != "" {
-			return p
-		}
-	case svc.Deploy != nil && svc.Deploy.RestartPolicy != nil: // docker-compose v3
-		if p := inferRestartPolicyFromComposeValue(svc.Deploy.RestartPolicy.Condition); p != "" {
-			return p
-		}
+	policy := DefaultRestartPolicy
+
+	if svc.Restart != "" {
+		policy = inferRestartPolicyFromComposeValue(svc.Restart)
 	}
-	return DefaultRestartPolicy
+
+	if svc.Deploy != nil && svc.Deploy.RestartPolicy != nil {
+		policy = inferRestartPolicyFromComposeValue(svc.Deploy.RestartPolicy.Condition)
+	}
+
+	return policy
 }
 
 func WorkloadReplicasFromCompose(svc *composego.ServiceConfig) int {

--- a/pkg/kev/config/svcext_test.go
+++ b/pkg/kev/config/svcext_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Service Extension", func() {
 
 		Describe("validations", func() {
 			Context("from svc to k8s ext", func() {
-				Context("with missing workload", func() {
+				Context("with missing workload configuration", func() {
 					BeforeEach(func() {
 						svc.Extensions = map[string]interface{}{
 							"x-k8s": map[string]interface{}{
@@ -98,7 +98,7 @@ var _ = Describe("Service Extension", func() {
 					})
 				})
 
-				Context("invalid/empty workload", func() {
+				Context("with invalid/empty workload configuration", func() {
 					BeforeEach(func() {
 						svc.Extensions = map[string]interface{}{
 							"x-k8s": map[string]interface{}{
@@ -109,14 +109,12 @@ var _ = Describe("Service Extension", func() {
 						}
 					})
 
-					When("workload is invalid", func() {
-						It("it is ignored and returns defaults", func() {
-							Expect(parsedK8sCfg).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
-						})
+					It("it is ignored and returns defaults", func() {
+						Expect(parsedK8sCfg).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
 					})
 				})
 
-				Context("missing liveness probe type", func() {
+				Context("missing liveness probe type in workload configuration", func() {
 					BeforeEach(func() {
 						svc.Extensions = map[string]interface{}{
 							config.K8SExtensionKey: map[string]interface{}{
@@ -128,10 +126,8 @@ var _ = Describe("Service Extension", func() {
 						}
 					})
 
-					When("liveness probe type not provided", func() {
-						It("return default probe", func() {
-							Expect(parsedK8sCfg.Workload.LivenessProbe).To(Equal(config.DefaultLivenessProbe()))
-						})
+					It("returns default probe", func() {
+						Expect(parsedK8sCfg.Workload.LivenessProbe).To(Equal(config.DefaultLivenessProbe()))
 					})
 				})
 
@@ -161,6 +157,7 @@ var _ = Describe("Service Extension", func() {
 							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
 						})
 					})
+
 					When("unless-stopped policy set in Restart Config", func() {
 						BeforeEach(func() {
 							svc.Restart = "unless-stopped"
@@ -169,6 +166,7 @@ var _ = Describe("Service Extension", func() {
 							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
 						})
 					})
+
 					When("invalid policy set in Deploy Config", func() {
 						BeforeEach(func() {
 							svc.Deploy = &composego.DeployConfig{
@@ -177,6 +175,7 @@ var _ = Describe("Service Extension", func() {
 								},
 							}
 						})
+
 						It("sets the default policy", func() {
 							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
 						})
@@ -192,10 +191,12 @@ var _ = Describe("Service Extension", func() {
 								},
 							}
 						})
+
 						It("should error", func() {
 							Expect(err).To(HaveOccurred())
 						})
 					})
+
 					When("policy is missing in extension", func() {
 						BeforeEach(func() {
 							svc.Extensions = map[string]interface{}{
@@ -206,6 +207,7 @@ var _ = Describe("Service Extension", func() {
 								},
 							}
 						})
+
 						It("sets the default policy", func() {
 							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
 						})
@@ -224,6 +226,7 @@ var _ = Describe("Service Extension", func() {
 						Expect(err.Error()).To(Equal("SvcK8sConfig.Service.Type is required"))
 					})
 				})
+
 				Context("with a missing workload type", func() {
 					It("returns error", func() {
 						svcK8sConfig := config.DefaultSvcK8sConfig()

--- a/pkg/kev/config/svcext_test.go
+++ b/pkg/kev/config/svcext_test.go
@@ -27,37 +27,36 @@ import (
 )
 
 var _ = Describe("Service Extension", func() {
+	var (
+		err          error
+		parsedK8sCfg config.SvcK8sConfig
+		svc          composego.ServiceConfig
+	)
+
+	JustBeforeEach(func() {
+		parsedK8sCfg, err = config.SvcK8sConfigFromCompose(&svc)
+	})
+
+	AfterEach(func() {
+		svc.Extensions = nil
+		svc.Restart = ""
+		svc.Deploy = nil
+	})
 
 	Describe("parsing", func() {
-		var (
-			k8sCfg config.SvcK8sConfig
-			err    error
-
-			parsedK8sCfg config.SvcK8sConfig
-			svc          composego.ServiceConfig
-		)
-
-		BeforeEach(func() {
-			k8sCfg = config.SvcK8sConfig{}
-		})
-
-		JustBeforeEach(func() {
-			m, err := k8sCfg.ToMap()
-			Expect(err).NotTo(HaveOccurred())
-			svc.Extensions = map[string]interface{}{
-				config.K8SExtensionKey: m,
-			}
-
-			parsedK8sCfg, err = config.SvcK8sConfigFromCompose(&svc)
-			Expect(err).NotTo(HaveOccurred())
-
-		})
-
 		Context("works with defaults", func() {
 			BeforeEach(func() {
-				k8sCfg.Workload.Type = "Deployment"
-				k8sCfg.Workload.Replicas = 10
-				k8sCfg.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
+				svc.Extensions = map[string]interface{}{
+					config.K8SExtensionKey: map[string]interface{}{
+						"workload": map[string]interface{}{
+							"type":     "Deployment",
+							"replicas": 10,
+							"livenessProbe": map[string]interface{}{
+								"type": "none",
+							},
+						},
+					},
+				}
 			})
 
 			It("creates the config using defaults when the mandatory properties are present", func() {
@@ -73,8 +72,6 @@ var _ = Describe("Service Extension", func() {
 		When("there is no k8s extension present", func() {
 			Context("Without RequirePresent configuration", func() {
 				It("does not fail validations", func() {
-					parsedK8sCfg, err = config.SvcK8sConfigFromCompose(&svc)
-					Expect(err).ToNot(HaveOccurred())
 					Expect(parsedK8sCfg).NotTo(BeNil())
 
 					Expect(parsedK8sCfg.Workload.Replicas).To(Equal(config.DefaultReplicaNumber))
@@ -85,88 +82,157 @@ var _ = Describe("Service Extension", func() {
 		})
 
 		Describe("validations", func() {
-			Context("with missing workload", func() {
-				JustBeforeEach(func() {
-					svc.Extensions = map[string]interface{}{
-						"x-k8s": map[string]interface{}{
-							"bananas": 1,
-						},
-					}
-
-					parsedK8sCfg, err = config.SvcK8sConfigFromCompose(&svc)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("returns defaults", func() {
-					defaultWorkload := config.DefaultSvcK8sConfig().Workload
-					Expect(parsedK8sCfg.Workload).To(BeEquivalentTo(defaultWorkload))
-				})
-			})
-
-			Context("invalid/empty workload", func() {
-				JustBeforeEach(func() {
-					svc.Extensions = map[string]interface{}{
-						"x-k8s": map[string]interface{}{
-							"workload": map[string]interface{}{
+			Context("from svc to k8s ext", func() {
+				Context("with missing workload", func() {
+					BeforeEach(func() {
+						svc.Extensions = map[string]interface{}{
+							"x-k8s": map[string]interface{}{
 								"bananas": 1,
 							},
-						},
-					}
+						}
+					})
 
-					parsedK8sCfg, err = config.SvcK8sConfigFromCompose(&svc)
-					Expect(err).NotTo(HaveOccurred())
+					It("returns defaults", func() {
+						defaultWorkload := config.DefaultSvcK8sConfig().Workload
+						Expect(parsedK8sCfg.Workload).To(BeEquivalentTo(defaultWorkload))
+					})
 				})
 
-				When("workload is invalid", func() {
-					It("it is ignored and returns defaults", func() {
-						Expect(parsedK8sCfg).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
+				Context("invalid/empty workload", func() {
+					BeforeEach(func() {
+						svc.Extensions = map[string]interface{}{
+							"x-k8s": map[string]interface{}{
+								"workload": map[string]interface{}{
+									"bananas": 1,
+								},
+							},
+						}
+					})
+
+					When("workload is invalid", func() {
+						It("it is ignored and returns defaults", func() {
+							Expect(parsedK8sCfg).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
+						})
+					})
+				})
+
+				Context("missing liveness probe type", func() {
+					BeforeEach(func() {
+						svc.Extensions = map[string]interface{}{
+							config.K8SExtensionKey: map[string]interface{}{
+								"workload": map[string]interface{}{
+									"type":     "Deployment",
+									"replicas": 10,
+								},
+							},
+						}
+					})
+
+					When("liveness probe type not provided", func() {
+						It("return default probe", func() {
+							Expect(parsedK8sCfg.Workload.LivenessProbe).To(Equal(config.DefaultLivenessProbe()))
+						})
+					})
+				})
+
+				Context("missing replicas", func() {
+					BeforeEach(func() {
+						svc.Extensions = map[string]interface{}{
+							config.K8SExtensionKey: map[string]interface{}{
+								"workload": map[string]interface{}{
+									"replicas": 0,
+								},
+							},
+						}
+					})
+
+					It("returns in defaults", func() {
+						defaultReplicas := config.DefaultSvcK8sConfig().Workload.Replicas
+						Expect(parsedK8sCfg.Workload.Replicas).To(BeEquivalentTo(defaultReplicas))
+					})
+				})
+
+				Context("restart policy", func() {
+					When("invalid policy set in Restart Config", func() {
+						BeforeEach(func() {
+							svc.Restart = "invalid"
+						})
+						It("sets the default policy", func() {
+							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
+						})
+					})
+					When("unless-stopped policy set in Restart Config", func() {
+						BeforeEach(func() {
+							svc.Restart = "unless-stopped"
+						})
+						It("sets the default policy", func() {
+							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
+						})
+					})
+					When("invalid policy set in Deploy Config", func() {
+						BeforeEach(func() {
+							svc.Deploy = &composego.DeployConfig{
+								RestartPolicy: &composego.RestartPolicy{
+									Condition: "invalid",
+								},
+							}
+						})
+						It("sets the default policy", func() {
+							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
+						})
+					})
+
+					When("invalid policy set in extension", func() {
+						BeforeEach(func() {
+							svc.Extensions = map[string]interface{}{
+								config.K8SExtensionKey: map[string]interface{}{
+									"workload": map[string]interface{}{
+										"restartPolicy": "invalid",
+									},
+								},
+							}
+						})
+						It("should error", func() {
+							Expect(err).To(HaveOccurred())
+						})
+					})
+					When("policy is missing in extension", func() {
+						BeforeEach(func() {
+							svc.Extensions = map[string]interface{}{
+								config.K8SExtensionKey: map[string]interface{}{
+									"workload": map[string]interface{}{
+										"restartPolicy": "",
+									},
+								},
+							}
+						})
+						It("sets the default policy", func() {
+							Expect(parsedK8sCfg.Workload.RestartPolicy).To(Equal(config.RestartPolicyAlways))
+						})
 					})
 				})
 			})
 
-			Context("missing liveness probe type", func() {
-				BeforeEach(func() {
-					k8sCfg.Workload.Type = config.DefaultWorkload
-					k8sCfg.Workload.Replicas = 10
-				})
+			Context("when running validate", func() {
+				Context("with a missing service type", func() {
+					It("returns error", func() {
+						svcK8sConfig := config.DefaultSvcK8sConfig()
+						svcK8sConfig.Service.Type = ""
 
-				When("liveness probe type not provided", func() {
-					It("return default probe", func() {
-						Expect(parsedK8sCfg.Workload.LivenessProbe).To(Equal(config.DefaultLivenessProbe()))
+						err = svcK8sConfig.Validate()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Equal("SvcK8sConfig.Service.Type is required"))
 					})
 				})
-			})
+				Context("with a missing workload type", func() {
+					It("returns error", func() {
+						svcK8sConfig := config.DefaultSvcK8sConfig()
+						svcK8sConfig.Workload.Type = ""
 
-			Context("missing replicas", func() {
-				BeforeEach(func() {
-					k8sCfg.Workload.Replicas = 0
-				})
-
-				It("returns in defaults", func() {
-					defaultReplicas := config.DefaultSvcK8sConfig().Workload.Replicas
-					Expect(parsedK8sCfg.Workload.Replicas).To(BeEquivalentTo(defaultReplicas))
-				})
-			})
-
-			Context("missing service type", func() {
-				It("returns error", func() {
-					k8sconf := config.DefaultSvcK8sConfig()
-					k8sconf.Service.Type = ""
-
-					err = k8sconf.Validate()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("SvcK8sConfig.Service.Type is required"))
-				})
-			})
-
-			Context("missing workload type", func() {
-				It("returns error", func() {
-					k8sconf := config.DefaultSvcK8sConfig()
-					k8sconf.Workload.Type = ""
-
-					err = k8sconf.Validate()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("SvcK8sConfig.Workload.Type is required"))
+						err = svcK8sConfig.Validate()
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Equal("SvcK8sConfig.Workload.Type is required"))
+					})
 				})
 			})
 		})
@@ -220,42 +286,25 @@ var _ = Describe("Service Extension", func() {
 		})
 
 		Context("Fallback", func() {
-			var extensions map[string]interface{}
-			var svc composego.ServiceConfig
-
-			var parsedConf config.SvcK8sConfig
-			var err error
-
-			JustBeforeEach(func() {
-				svc.Extensions = extensions
-				parsedConf, err = config.SvcK8sConfigFromCompose(&svc)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
 			Context("configs are empty", func() {
 				BeforeEach(func() {
-					extensions = make(map[string]interface{})
+					svc.Extensions = make(map[string]interface{})
 				})
 
 				It("returns default when map is empty", func() {
-					result, err := config.DefaultSvcK8sConfig().Merge(parsedConf)
+					result, err := config.DefaultSvcK8sConfig().Merge(parsedK8sCfg)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
 				})
 			})
 
 			Context("configs are invalid", func() {
-				BeforeEach(func() {
-					extensions = nil
-				})
-
 				It("returns default when map is nil", func() {
-					result, err := config.DefaultSvcK8sConfig().Merge(parsedConf)
+					result, err := config.DefaultSvcK8sConfig().Merge(parsedK8sCfg)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeEquivalentTo(config.DefaultSvcK8sConfig()))
 				})
 			})
 		})
 	})
-
 })

--- a/pkg/kev/converter/kubernetes/probes.go
+++ b/pkg/kev/converter/kubernetes/probes.go
@@ -32,8 +32,8 @@ func v1probe(probeType string, pc config.ProbeConfig) (*v1.Probe, error) {
 		InitialDelaySeconds: int32(pc.InitialDelay.Seconds()),
 		TimeoutSeconds:      int32(pc.Timeout.Seconds()),
 		PeriodSeconds:       int32(pc.Period.Seconds()),
-		SuccessThreshold:    int32(pc.FailureThreashold),
-		FailureThreshold:    int32(pc.FailureThreashold),
+		SuccessThreshold:    int32(pc.FailureThreshold),
+		FailureThreshold:    int32(pc.FailureThreshold),
 	}, nil
 }
 

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -322,21 +322,6 @@ func (p *ProjectService) serviceAccountName() string {
 
 // restartPolicy return workload restart policy. Supports both docker-compose and Kubernetes notations.
 func (p *ProjectService) restartPolicy() v1.RestartPolicy {
-	// policy := config.RestartPolicyAlways
-	// if p.SvcK8sConfig.Workload.RestartPolicy != "" {
-	// 	policy = p.SvcK8sConfig.Workload.RestartPolicy
-	// }
-
-	// restartPolicy, err := getRestartPolicy(p.Name, policy)
-	// if err != nil {
-	// 	log.WarnWithFields(log.Fields{
-	// 		"project-service": p.Name,
-	// 		"restart-policy":  policy,
-	// 	}, "Restart policy is not supported, defaulting to 'Always'")
-	//
-	// 	return v1.RestartPolicy(config.RestartPolicyAlways)
-	// }
-
 	return v1.RestartPolicy(p.SvcK8sConfig.Workload.RestartPolicy)
 }
 

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -322,22 +322,22 @@ func (p *ProjectService) serviceAccountName() string {
 
 // restartPolicy return workload restart policy. Supports both docker-compose and Kubernetes notations.
 func (p *ProjectService) restartPolicy() v1.RestartPolicy {
-	policy := config.RestartPolicyAlways
-	if p.SvcK8sConfig.Workload.RestartPolicy != "" {
-		policy = p.SvcK8sConfig.Workload.RestartPolicy
-	}
+	// policy := config.RestartPolicyAlways
+	// if p.SvcK8sConfig.Workload.RestartPolicy != "" {
+	// 	policy = p.SvcK8sConfig.Workload.RestartPolicy
+	// }
 
-	restartPolicy, err := getRestartPolicy(p.Name, policy)
-	if err != nil {
-		log.WarnWithFields(log.Fields{
-			"project-service": p.Name,
-			"restart-policy":  policy,
-		}, "Restart policy is not supported, defaulting to 'Always'")
+	// restartPolicy, err := getRestartPolicy(p.Name, policy)
+	// if err != nil {
+	// 	log.WarnWithFields(log.Fields{
+	// 		"project-service": p.Name,
+	// 		"restart-policy":  policy,
+	// 	}, "Restart policy is not supported, defaulting to 'Always'")
+	//
+	// 	return v1.RestartPolicy(config.RestartPolicyAlways)
+	// }
 
-		return config.RestartPolicyAlways
-	}
-
-	return restartPolicy
+	return v1.RestartPolicy(p.SvcK8sConfig.Workload.RestartPolicy)
 }
 
 // environment returns composego project service environment variables, and evaluates ENV from OS

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1769,7 +1769,11 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 		template.Spec.Containers[0].ImagePullPolicy = projectService.imagePullPolicy()
 
 		// @step configure the container restart policy.
-		template.Spec.RestartPolicy = projectService.restartPolicy()
+		restartPolicy, err := projectService.restartPolicy()
+		if err != nil {
+			return err
+		}
+		template.Spec.RestartPolicy = restartPolicy
 
 		// @step configure hostname/domain_name settings
 		if projectService.Hostname != "" {

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -301,8 +301,7 @@ var _ = Describe("Reconcile", func() {
 				It("should configure parse config into extensions", func() {
 					expected, err := newDefaultServiceExtensions("wordpress", config.SvcK8sConfig{
 						Workload: config.Workload{
-							Replicas:      3,
-							RestartPolicy: "always",
+							Replicas: 3,
 							Resource: config.Resource{
 								CPU:       "0.25",
 								MaxCPU:    "0.25",
@@ -332,7 +331,6 @@ var _ = Describe("Reconcile", func() {
 				It("should configure the added service extensions from healthcheck config", func() {
 					expected, err := newDefaultServiceExtensions("wordpress", config.SvcK8sConfig{
 						Workload: config.Workload{
-							RestartPolicy: "always",
 							Resource: config.Resource{
 								Memory:    "10Mi",
 								MaxMemory: "500Mi",
@@ -583,7 +581,7 @@ func newDefaultServiceExtensions(_ string, svcK8sConfigs ...config.SvcK8sConfig)
 			Type:                  config.DefaultWorkload,
 			Replicas:              config.DefaultReplicaNumber,
 			RollingUpdateMaxSurge: config.DefaultRollingUpdateMaxSurge,
-			RestartPolicy:         "always",
+			RestartPolicy:         config.DefaultRestartPolicy,
 			ImagePull: config.ImagePull{
 				Policy: config.DefaultImagePullPolicy,
 			},

--- a/pkg/kev/testdata/init-default/compose-yaml/output.yaml
+++ b/pkg/kev/testdata/init-default/compose-yaml/output.yaml
@@ -16,13 +16,13 @@ services:
             command:
             - echo
             - Define healthcheck command for service
-          failureThreashold: 3
+          failureThreshold: 3
           initialDelay: 1m0s
           period: 1m0s
           timeout: 10s
           type: exec
         readinessProbe:
-          failureThreashold: 3
+          failureThreshold: 3
           initialDelay: 1m0s
           period: 1m0s
           timeout: 10s
@@ -33,7 +33,7 @@ services:
           maxCpu: "0.5"
           maxMemory: 500Mi
           memory: 10Mi
-        restartPolicy: always
+        restartPolicy: Always
         rollingUpdateMaxSurge: 1
         serviceAccountName: default
         type: StatefulSet

--- a/pkg/kev/testdata/init-default/docker-compose-yml/docker-compose.yml
+++ b/pkg/kev/testdata/init-default/docker-compose-yml/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '2.4'
 services:
   db:
     image: mysql:8.0.19

--- a/pkg/kev/testdata/init-default/docker-compose-yml/docker-compose.yml
+++ b/pkg/kev/testdata/init-default/docker-compose-yml/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '3.9'
 services:
   db:
     image: mysql:8.0.19


### PR DESCRIPTION
Resolves #493 

- Moved Restart Policy to use enums and clarified inference logic.
- Updated the render phase to use the svc K8s config value directly.
- Added tests to check the various Restart Policy scenarios.