### PR TITLE
Turn Workload Type and Service Type value sets into enums

### DIFF
--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -32,7 +32,7 @@ const (
 	// DefaultRestartPolicy is a default restart policy
 	DefaultRestartPolicy = RestartPolicyAlways
 
-	// DefaultWorkload is a defauld workload type
+	// DefaultWorkload is a default workload type
 	DefaultWorkload = DeploymentWorkload
 
 	// DefaultServiceAccountName is a default SA to be used
@@ -58,15 +58,6 @@ const (
 
 	// HeadlessService svc type
 	HeadlessService = "Headless"
-
-	// DeploymentWorkload workload type
-	DeploymentWorkload = "Deployment"
-
-	// DaemonsetWorkload workload type
-	DaemonsetWorkload = "DaemonSet"
-
-	// StatefulsetWorkload workload type
-	StatefulsetWorkload = "StatefulSet"
 
 	// JobWorkload workload type
 	JobWorkload = "Job"

--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -44,21 +44,6 @@ const (
 	// DefaultImagePullSecret default image pull credentials secret name
 	DefaultImagePullSecret = ""
 
-	// NoService default value
-	NoService = "None"
-
-	// NodePortService svc type
-	NodePortService = "NodePort"
-
-	// LoadBalancerService svc type
-	LoadBalancerService = "LoadBalancer"
-
-	// ClusterIPService svc type
-	ClusterIPService = "ClusterIP"
-
-	// HeadlessService svc type
-	HeadlessService = "Headless"
-
 	// JobWorkload workload type
 	JobWorkload = "Job"
 

--- a/pkg/kev/config/service.go
+++ b/pkg/kev/config/service.go
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2021 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+type ServiceType string
+
+const (
+	// NoService default value
+	NoService ServiceType = "None"
+
+	// NodePortService svc type
+	NodePortService ServiceType = "NodePort"
+
+	// LoadBalancerService svc type
+	LoadBalancerService ServiceType = "LoadBalancer"
+
+	// ClusterIPService svc type
+	ClusterIPService ServiceType = "ClusterIP"
+
+	// HeadlessService svc type
+	HeadlessService ServiceType = "Headless"
+)
+
+// String converts a service type to a string value
+func (s ServiceType) String() string {
+	return string(s)
+}
+
+// serviceTypes are the only service type settings
+var serviceTypes = map[ServiceType]bool{
+	NoService:           true,
+	NodePortService:     true,
+	LoadBalancerService: true,
+	ClusterIPService:    true,
+	HeadlessService:     true,
+}
+
+// ServiceTypeFromValue returns a Service Type for a given case insensitive value.
+// Returns a blank string and false for unknown values.
+func ServiceTypeFromValue(s string) (ServiceType, bool) {
+	for k, v := range serviceTypes {
+		if strings.ToLower(k.String()) == strings.ToLower(s) {
+			return k, v
+		}
+	}
+	return "", false
+}
+
+// ServiceTypesEqual checks if the supplied ServiceTypes are equal
+func ServiceTypesEqual(s, t ServiceType) bool {
+	return strings.ToLower(s.String()) == strings.ToLower(t.String())
+}
+
+// validateServiceType validator to validate a service type
+func validateServiceType(fl validator.FieldLevel) bool {
+	_, valid := ServiceTypeFromValue(fl.Field().String())
+	return valid
+}
+
+// inferServiceTypeFromComposeValue returns service type based on passed string value
+// @orig: https://github.com/kubernetes/kompose/blob/1f0a097836fb4e0ae4a802eb7ab543a4f9493727/pkg/loader/compose/utils.go#L108
+// func inferServiceTypeFromComposeValue(v string) (string, error) {
+func inferServiceTypeFromComposeValue(v string) (ServiceType, error) {
+	switch strings.ToLower(v) {
+	case "", "clusterip":
+		return ClusterIPService, nil
+	case "nodeport":
+		return NodePortService, nil
+	case "loadbalancer":
+		return NodePortService, nil
+	case "headless":
+		return HeadlessService, nil
+	case "none":
+		return NoService, nil
+	default:
+		return "", fmt.Errorf("unknown value %s, supported values are 'none, nodeport, clusterip, headless or loadbalancer'", v)
+	}
+}

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -29,7 +29,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/imdario/mergo"
 	"gopkg.in/yaml.v3"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -293,11 +292,11 @@ func ServiceTypeFromCompose(svc *composego.ServiceConfig) (string, error) {
 func getServiceType(serviceType string) (string, error) {
 	switch strings.ToLower(serviceType) {
 	case "", "clusterip":
-		return string(v1.ServiceTypeClusterIP), nil
+		return ClusterIPService, nil
 	case "nodeport":
-		return string(v1.ServiceTypeNodePort), nil
+		return NodePortService, nil
 	case "loadbalancer":
-		return string(v1.ServiceTypeLoadBalancer), nil
+		return NodePortService, nil
 	case "headless":
 		return HeadlessService, nil
 	case "none":

--- a/pkg/kev/config/svcext_test.go
+++ b/pkg/kev/config/svcext_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Service Extension", func() {
 
 						err = svcK8sConfig.Validate()
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(Equal("SvcK8sConfig.Workload.Type is required"))
+						Expect(err.Error()).To(ContainSubstring("SvcK8sConfig.Workload.Type"))
 					})
 				})
 			})

--- a/pkg/kev/config/svcext_test.go
+++ b/pkg/kev/config/svcext_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Service Extension", func() {
 
 						err = svcK8sConfig.Validate()
 						Expect(err).To(HaveOccurred())
-						Expect(err.Error()).To(Equal("SvcK8sConfig.Service.Type is required"))
+						Expect(err.Error()).To(ContainSubstring("SvcK8sConfig.Service.Type"))
 					})
 				})
 

--- a/pkg/kev/config/workload.go
+++ b/pkg/kev/config/workload.go
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2021 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+type WorkloadType string
+
+const (
+	// DeploymentWorkload workload type
+	DeploymentWorkload WorkloadType = "Deployment"
+
+	// DaemonSetWorkload workload type
+	DaemonSetWorkload WorkloadType = "DaemonSet"
+
+	// StatefulSetWorkload workload type
+	StatefulSetWorkload WorkloadType = "StatefulSet"
+)
+
+// String converts a workload type to a string value
+func (w WorkloadType) String() string {
+	return string(w)
+}
+
+// workloadTypes are the only workload type settings
+var workloadTypes = map[WorkloadType]bool{
+	DeploymentWorkload:  true,
+	DaemonSetWorkload:   true,
+	StatefulSetWorkload: true,
+}
+
+// WorkloadTypeFromValue returns a Workload Type for a given case insensitive value.
+// Returns a blank string and false for unknown values.
+func WorkloadTypeFromValue(s string) (WorkloadType, bool) {
+	for k, v := range workloadTypes {
+		if strings.ToLower(k.String()) == strings.ToLower(s) {
+			return k, v
+		}
+	}
+	return "", false
+}
+
+// WorkloadTypesEqual checks if the supplied WorkloadTypes are equal
+func WorkloadTypesEqual(s, t WorkloadType) bool {
+	return strings.ToLower(s.String()) == strings.ToLower(t.String())
+}
+
+// validateWorkloadType validator to validate a workload type
+func validateWorkloadType(fl validator.FieldLevel) bool {
+	_, valid := WorkloadTypeFromValue(fl.Field().String())
+	return valid
+}

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -70,13 +70,13 @@ func (p *ProjectService) autoscaleTargetMemoryUtilization() int32 {
 }
 
 // workloadType returns workload type for the project service
-func (p *ProjectService) workloadType() string {
+func (p *ProjectService) workloadType() config.WorkloadType {
 	workloadType := p.SvcK8sConfig.Workload.Type
 
-	if p.Deploy != nil && p.Deploy.Mode == "global" && !strings.EqualFold(workloadType, config.DaemonsetWorkload) {
+	if p.Deploy != nil && p.Deploy.Mode == "global" && !config.WorkloadTypesEqual(workloadType, config.DaemonSetWorkload) {
 		log.WarnfWithFields(log.Fields{
 			"project-service": p.Name,
-			"workload-type":   workloadType,
+			"workload-type":   workloadType.String(),
 		}, "Compose service defined as 'global' should map to K8s DaemonSet. Current configuration forces conversion to %s",
 			workloadType)
 	}

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -89,7 +89,7 @@ func (p *ProjectService) serviceType() (config.ServiceType, error) {
 	serviceType := p.SvcK8sConfig.Service.Type
 
 	// @step validate whether service type is set properly when node port is specified
-	if !config.ServiceTypesEqual(serviceType, config.NodePortService) && p.nodePort() != 0 {
+	if !strings.EqualFold(string(serviceType), string(v1.ServiceTypeNodePort)) && p.nodePort() != 0 {
 		return "", fmt.Errorf("`%s` workload service type must be set as `NodePort` when assigning node port value", p.Name)
 	}
 

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -85,11 +85,11 @@ func (p *ProjectService) workloadType() config.WorkloadType {
 }
 
 // serviceType returns service type for project service workload
-func (p *ProjectService) serviceType() (string, error) {
+func (p *ProjectService) serviceType() (config.ServiceType, error) {
 	serviceType := p.SvcK8sConfig.Service.Type
 
 	// @step validate whether service type is set properly when node port is specified
-	if !strings.EqualFold(serviceType, string(v1.ServiceTypeNodePort)) && p.nodePort() != 0 {
+	if !config.ServiceTypesEqual(serviceType, config.NodePortService) && p.nodePort() != 0 {
 		return "", fmt.Errorf("`%s` workload service type must be set as `NodePort` when assigning node port value", p.Name)
 	}
 
@@ -98,6 +98,15 @@ func (p *ProjectService) serviceType() (string, error) {
 	}
 
 	return serviceType, nil
+}
+
+// toV1ServiceType maps to a case-sensitive v1 service type
+func toV1ServiceType(st config.ServiceType) (v1.ServiceType, error) {
+	caseSensitiveSvcType, ok := config.ServiceTypeFromValue(st.String())
+	if !ok {
+		return "", errors.New("invalid service type")
+	}
+	return v1.ServiceType(caseSensitiveSvcType), nil
 }
 
 // nodePort returns the port for NodePort service type

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -237,8 +237,7 @@ var _ = Describe("ProjectService", func() {
 	Describe("workloadType", func() {
 
 		Context("when provided via extension", func() {
-
-			workloadType := "StatefulSet"
+			workloadType := config.StatefulSetWorkload
 
 			JustBeforeEach(func() {
 				projectService.SvcK8sConfig.Workload.Type = workloadType
@@ -256,7 +255,7 @@ var _ = Describe("ProjectService", func() {
 		})
 
 		Context("when deploy block `mode` defined as `global` and workload type is different than DaemonSet", func() {
-			projectWorkloadType := config.StatefulsetWorkload
+			projectWorkloadType := config.StatefulSetWorkload
 
 			JustBeforeEach(func() {
 				projectService.SvcK8sConfig.Workload.Type = projectWorkloadType
@@ -283,7 +282,7 @@ var _ = Describe("ProjectService", func() {
 				assertLog(logrus.WarnLevel,
 					"Compose service defined as 'global' should map to K8s DaemonSet. Current configuration forces conversion to StatefulSet",
 					map[string]string{
-						"workload-type":   projectWorkloadType,
+						"workload-type":   projectWorkloadType.String(),
 						"project-service": projectServiceName,
 					},
 				)

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -320,7 +320,7 @@ var _ = Describe("ProjectService", func() {
 				JustBeforeEach(func() {
 					var err error
 					svcK8sConfig := config.SvcK8sConfig{}
-					svcK8sConfig.Service.Type = invalidType
+					svcK8sConfig.Service.Type = config.ServiceType(invalidType)
 
 					m, err = svcK8sConfig.ToMap()
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1778,7 +1778,8 @@ var _ = Describe("Transform", func() {
 
 		Context("for headless service type", func() {
 			It("creates headless service", func() {
-				svc := k.createService(config.HeadlessService, projectService)
+				svc, err := k.createService(config.HeadlessService, projectService)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(svc.Spec.Type).To(Equal(v1.ServiceTypeClusterIP))
 				Expect(svc.Spec.ClusterIP).To(Equal("None"))
 				Expect(svc.ObjectMeta.Annotations).To(Equal(configAnnotations(projectService)))
@@ -1788,7 +1789,8 @@ var _ = Describe("Transform", func() {
 
 		Context("for any other service type", func() {
 			It("creates a service", func() {
-				svc := k.createService(config.NodePortService, projectService)
+				svc, err := k.createService(config.NodePortService, projectService)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(svc.Spec.Type).To(Equal(v1.ServiceTypeNodePort))
 				Expect(svc.ObjectMeta.Annotations).To(Equal(configAnnotations(projectService)))
 				Expect(svc.Spec.Ports).To(Equal(expectedPorts))

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -35,7 +35,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/appvia/kev/pkg/kev/config"
 	"github.com/appvia/kev/pkg/kev/log"
 	composego "github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"
@@ -479,25 +478,6 @@ func getRestartPolicy(projectServiceName, restart string) (v1.RestartPolicy, err
 		return v1.RestartPolicyOnFailure, nil
 	default:
 		return "", fmt.Errorf("Unknown restart policy %s for service %s", restart, projectServiceName)
-	}
-}
-
-// getServiceType returns service type based on passed string value
-// @orig: https://github.com/kubernetes/kompose/blob/1f0a097836fb4e0ae4a802eb7ab543a4f9493727/pkg/loader/compose/utils.go#L108
-func getServiceType(serviceType string) (string, error) {
-	switch strings.ToLower(serviceType) {
-	case "", "clusterip":
-		return string(v1.ServiceTypeClusterIP), nil
-	case "nodeport":
-		return string(v1.ServiceTypeNodePort), nil
-	case "loadbalancer":
-		return string(v1.ServiceTypeLoadBalancer), nil
-	case "headless":
-		return config.HeadlessService, nil
-	case "none":
-		return config.NoService, nil
-	default:
-		return "", fmt.Errorf("Unknown value %s, supported values are 'none, nodeport, clusterip, headless or loadbalancer'", serviceType)
 	}
 }
 

--- a/pkg/kev/converter/kubernetes/utils_test.go
+++ b/pkg/kev/converter/kubernetes/utils_test.go
@@ -19,7 +19,6 @@ package kubernetes
 import (
 	"fmt"
 
-	"github.com/appvia/kev/pkg/kev/config"
 	composego "github.com/compose-spec/compose-go/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -160,35 +159,6 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
-	Describe("getServiceType", func() {
-
-		Context("for valid service type string", func() {
-			It("returns corresponding v1.ServiceType string", func() {
-				Expect(getServiceType("")).To(Equal(string(v1.ServiceTypeClusterIP)))
-				Expect(getServiceType("ClusterIP")).To(Equal(string(v1.ServiceTypeClusterIP)))
-				Expect(getServiceType("NodePort")).To(Equal(string(v1.ServiceTypeNodePort)))
-				Expect(getServiceType("LoadBalancer")).To(Equal(string(v1.ServiceTypeLoadBalancer)))
-				Expect(getServiceType("Headless")).To(Equal(config.HeadlessService))
-				Expect(getServiceType("None")).To(Equal(config.NoService))
-			})
-
-			It("restart service type string is case insensitive", func() {
-				Expect(getServiceType("clusterip")).To(Equal(string(v1.ServiceTypeClusterIP)))
-				Expect(getServiceType("CLUSTERIP")).To(Equal(string(v1.ServiceTypeClusterIP)))
-			})
-		})
-
-		Context("for service type string", func() {
-			sType := "INVALID"
-
-			It("returns an error", func() {
-				_, err := getServiceType(sType)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(fmt.Errorf("Unknown value %s, supported values are 'none, nodeport, clusterip, headless or loadbalancer'", sType)))
-			})
-		})
-	})
-
 	Describe("sortServices", func() {
 		s1, err := NewProjectService(composego.ServiceConfig{Name: "z"})
 		Expect(err).NotTo(HaveOccurred())
@@ -201,9 +171,9 @@ var _ = Describe("Utils", func() {
 
 		p := composego.Project{
 			Services: append(services,
-				composego.ServiceConfig(s1.ServiceConfig),
-				composego.ServiceConfig(s2.ServiceConfig),
-				composego.ServiceConfig(s3.ServiceConfig),
+				s1.ServiceConfig,
+				s2.ServiceConfig,
+				s3.ServiceConfig,
 			),
 		}
 

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Reconcile", func() {
 					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(svcK8sConfig.Service.Type).To(Equal("LoadBalancer"))
+					Expect(svcK8sConfig.Service.Type).To(Equal(config.LoadBalancerService))
 				})
 
 				It("should not update any of the environments", func() {
@@ -224,7 +224,7 @@ var _ = Describe("Reconcile", func() {
 					svcK8sConfig, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(svcK8sConfig.Service.Type).To(Equal("LoadBalancer"))
+					Expect(svcK8sConfig.Service.Type).To(Equal(config.LoadBalancerService))
 				})
 
 				It("should log the change summary using the debug level", func() {


### PR DESCRIPTION
Resolves #532 

- Workload Types are now enums, and can handle case insensitive k8s extension config.
- Service Types are now enums, and can handle case insensitive k8s extension config.