### PR TITLE
Minify Extensions

### DIFF
--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -54,20 +54,28 @@ func (cset changeset) applyVersionPatchesIfAny(o *composeOverride) string {
 	return chg.patchVersion(o)
 }
 
-func (cset changeset) applyServicesPatchesIfAny(o *composeOverride) []string {
+func (cset changeset) applyServicesPatchesIfAny(o *composeOverride) ([]string, error) {
 	var out []string
 	for _, change := range cset.services {
-		out = append(out, change.patchService(o))
+		patchDetails, err := change.patchService(o)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, patchDetails)
 	}
-	return out
+	return out, nil
 }
 
-func (cset changeset) applyVolumesPatchesIfAny(o *composeOverride) []string {
+func (cset changeset) applyVolumesPatchesIfAny(o *composeOverride) ([]string, error) {
 	var out []string
 	for _, change := range cset.volumes {
-		out = append(out, change.patchVolume(o))
+		patchDetails, err := change.patchVolume(o)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, patchDetails)
 	}
-	return out
+	return out, nil
 }
 
 func (chg change) patchVersion(override *composeOverride) string {
@@ -83,27 +91,35 @@ func (chg change) patchVersion(override *composeOverride) string {
 	return msg
 }
 
-func (chg change) patchService(override *composeOverride) string {
+func (chg change) patchService(override *composeOverride) (string, error) {
 	switch chg.Type {
 	case CREATE:
 		newValue := chg.Value.(ServiceConfig)
+
+		minified, err := config.MinifySvcExtension(newValue.Extensions)
+		if err != nil {
+			return "", err
+		}
+
+		newValue.Extensions[config.K8SExtensionKey] = minified
 		override.Services = append(override.Services, newValue)
+
 		msg := fmt.Sprintf("added service: %s", newValue.Name)
 		log.Debugf(msg)
-		return msg
+		return msg, nil
 	case DELETE:
 		switch {
 		case chg.Parent == "environment":
 			delete(override.Services[chg.Index.(int)].Environment, chg.Target)
 			msg := fmt.Sprintf("removed env var: %s from service %s", chg.Target, override.Services[chg.Index.(int)].Name)
 			log.Debugf(msg)
-			return msg
+			return msg, nil
 		default:
 			deletedSvcName := override.Services[chg.Index.(int)].Name
 			override.Services = append(override.Services[:chg.Index.(int)], override.Services[chg.Index.(int)+1:]...)
 			msg := fmt.Sprintf("removed service: %s", deletedSvcName)
 			log.Debugf(msg)
-			return msg
+			return msg, nil
 		}
 	case UPDATE:
 		switch chg.Parent {
@@ -114,7 +130,7 @@ func (chg change) patchService(override *composeOverride) string {
 			newValue, ok := chg.Value.(map[string]interface{})
 			if !ok {
 				log.Debugf("unable to update service [%s], invalid value %+v", svcName, newValue)
-				return ""
+				return "", nil
 			}
 
 			if svc.Extensions == nil {
@@ -125,22 +141,30 @@ func (chg change) patchService(override *composeOverride) string {
 			log.Debugf("service [%s] extensions updated to %+v", svcName, newValue)
 		}
 	}
-	return ""
+	return "", nil
 }
 
-func (chg change) patchVolume(override *composeOverride) string {
+func (chg change) patchVolume(override *composeOverride) (string, error) {
 	switch chg.Type {
 	case CREATE:
 		newValue := chg.Value.(VolumeConfig)
+
+		minified, err := config.MinifyVolExtension(newValue.Extensions)
+		if err != nil {
+			return "", err
+		}
+
+		newValue.Extensions[config.K8SExtensionKey] = minified
 		override.Volumes[chg.Index.(string)] = newValue
+
 		msg := fmt.Sprintf("added volume: %s", chg.Index.(string))
 		log.Debugf(msg)
-		return msg
+		return msg, nil
 	case DELETE:
 		delete(override.Volumes, chg.Index.(string))
 		msg := fmt.Sprintf("removed volume: %s", chg.Index.(string))
 		log.Debugf(msg)
-		return msg
+		return msg, nil
 	}
-	return ""
+	return "", nil
 }

--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -96,7 +96,7 @@ func (chg change) patchService(override *composeOverride) (string, error) {
 	case CREATE:
 		newValue := chg.Value.(ServiceConfig)
 
-		minified, err := config.MinifySvcExtension(newValue.Extensions)
+		minified, err := config.MinifySvcK8sExtension(newValue.Extensions)
 		if err != nil {
 			return "", err
 		}
@@ -149,7 +149,7 @@ func (chg change) patchVolume(override *composeOverride) (string, error) {
 	case CREATE:
 		newValue := chg.Value.(VolumeConfig)
 
-		minified, err := config.MinifyVolExtension(newValue.Extensions)
+		minified, err := config.MinifyVolK8sExtension(newValue.Extensions)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -17,9 +17,6 @@
 package config
 
 const (
-	// DefaultServiceEnabled default value for x-k8s.enabled
-	DefaultServiceEnabled = true
-
 	// DefaultVolumeSize default value PV class
 	DefaultVolumeSize = "100Mi"
 

--- a/pkg/kev/config/minify.go
+++ b/pkg/kev/config/minify.go
@@ -16,8 +16,8 @@
 
 package config
 
-// MinifySvcExtension creates a minimal service extension configuration using the supplied src.
-func MinifySvcExtension(src map[string]interface{}) (map[string]interface{}, error) {
+// MinifySvcK8sExtension creates a minimal service extension configuration using the supplied src.
+func MinifySvcK8sExtension(src map[string]interface{}) (map[string]interface{}, error) {
 	srcCfg, err := ParseSvcK8sConfigFromMap(src)
 	if err != nil {
 		return nil, err
@@ -50,8 +50,8 @@ func MinifySvcExtension(src map[string]interface{}) (map[string]interface{}, err
 	}.Map()
 }
 
-// MinifyVolExtension creates a minimal volume extension configuration using the supplied src.
-func MinifyVolExtension(src map[string]interface{}) (map[string]interface{}, error) {
+// MinifyVolK8sExtension creates a minimal volume extension configuration using the supplied src.
+func MinifyVolK8sExtension(src map[string]interface{}) (map[string]interface{}, error) {
 	srcCfg, err := ParseVolK8sConfigFromMap(src)
 	if err != nil {
 		return nil, err

--- a/pkg/kev/config/minify.go
+++ b/pkg/kev/config/minify.go
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2021 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+func MinifySvcExtension(src map[string]interface{}) (map[string]interface{}, error) {
+	srcCfg, err := ParseSvcK8sConfigFromMap(src)
+	if err != nil {
+		return nil, err
+	}
+
+	var probeConfig ProbeConfig
+	switch srcCfg.Workload.LivenessProbe.Type {
+	case ProbeTypeExec.String():
+		probeConfig = ProbeConfig{
+			Exec: srcCfg.Workload.LivenessProbe.ProbeConfig.Exec,
+		}
+	case ProbeTypeHTTP.String():
+		probeConfig = ProbeConfig{
+			HTTP: srcCfg.Workload.LivenessProbe.ProbeConfig.HTTP,
+		}
+	case ProbeTypeTCP.String():
+		probeConfig = ProbeConfig{
+			TCP: srcCfg.Workload.LivenessProbe.ProbeConfig.TCP,
+		}
+	}
+
+	return SvcK8sConfig{
+		Workload: Workload{
+			Replicas: srcCfg.Workload.Replicas,
+			LivenessProbe: LivenessProbe{
+				Type:        srcCfg.Workload.LivenessProbe.Type,
+				ProbeConfig: probeConfig,
+			},
+		},
+	}.Map()
+}
+
+func MinifyVolExtension(src map[string]interface{}) (map[string]interface{}, error) {
+	srcCfg, err := ParseVolK8sConfigFromMap(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return VolK8sConfig{Size: srcCfg.Size}.Map()
+}

--- a/pkg/kev/config/minify.go
+++ b/pkg/kev/config/minify.go
@@ -16,6 +16,7 @@
 
 package config
 
+// MinifySvcExtension creates a minimal service extension configuration using the supplied src.
 func MinifySvcExtension(src map[string]interface{}) (map[string]interface{}, error) {
 	srcCfg, err := ParseSvcK8sConfigFromMap(src)
 	if err != nil {
@@ -49,6 +50,7 @@ func MinifySvcExtension(src map[string]interface{}) (map[string]interface{}, err
 	}.Map()
 }
 
+// MinifyVolExtension creates a minimal volume extension configuration using the supplied src.
 func MinifyVolExtension(src map[string]interface{}) (map[string]interface{}, error) {
 	srcCfg, err := ParseVolK8sConfigFromMap(src)
 	if err != nil {

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -46,12 +46,12 @@ type ServiceExtension struct {
 
 // SvcK8sConfig represents the root of the k8s specific fields supported by kev.
 type SvcK8sConfig struct {
-	Disabled bool     `yaml:"disabled"`
+	Disabled bool     `yaml:"disabled,omitempty"`
 	Workload Workload `yaml:"workload" validate:"required,dive"`
 	Service  Service  `yaml:"service,omitempty"`
 }
 
-func (skc SvcK8sConfig) ToMap() (map[string]interface{}, error) {
+func (skc SvcK8sConfig) Map() (map[string]interface{}, error) {
 	bs, err := yaml.Marshal(skc)
 	if err != nil {
 		return nil, err
@@ -418,7 +418,7 @@ type Workload struct {
 	Type                  WorkloadType   `yaml:"type,omitempty" validate:"workloadType"`
 	Replicas              int            `yaml:"replicas" validate:""`
 	ServiceAccountName    string         `yaml:"serviceAccountName,omitempty" validate:"subdomainIfAny"`
-	RollingUpdateMaxSurge int            `yaml:"rollingUpdateMaxSurge" validate:""`
+	RollingUpdateMaxSurge int            `yaml:"rollingUpdateMaxSurge,omitempty" validate:""`
 	LivenessProbe         LivenessProbe  `yaml:"livenessProbe" validate:"required"`
 	ReadinessProbe        ReadinessProbe `yaml:"readinessProbe,omitempty"`
 	RestartPolicy         RestartPolicy  `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`

--- a/pkg/kev/config/volext.go
+++ b/pkg/kev/config/volext.go
@@ -39,7 +39,7 @@ type VolumeExtension struct {
 
 // VolK8sConfig represents the root of the k8s specific fields supported by kev.
 type VolK8sConfig struct {
-	Size         string `yaml:"size,omitempty" validate:"required,quantity"`
+	Size         string `yaml:"size" validate:"required,quantity"`
 	StorageClass string `yaml:"storageClass,omitempty"`
 	Selector     string `yaml:"selector,omitempty"`
 }
@@ -94,8 +94,7 @@ func (vkc VolK8sConfig) Validate() error {
 // DefaultVolK8sConfig returns a volume's K8s config with set defaults.
 func DefaultVolK8sConfig() VolK8sConfig {
 	return VolK8sConfig{
-		Size:         DefaultVolumeSize,
-		StorageClass: DefaultVolumeStorageClass,
+		Size: DefaultVolumeSize,
 	}
 }
 

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ProjectService", func() {
 	})
 
 	JustBeforeEach(func() {
-		ext, err := svcK8sConfig.ToMap()
+		ext, err := svcK8sConfig.Map()
 		Expect(err).NotTo(HaveOccurred())
 		extensions = map[string]interface{}{
 			config.K8SExtensionKey: ext,
@@ -259,7 +259,7 @@ var _ = Describe("ProjectService", func() {
 
 			JustBeforeEach(func() {
 				projectService.SvcK8sConfig.Workload.Type = projectWorkloadType
-				m, err := projectService.SvcK8sConfig.ToMap()
+				m, err := projectService.SvcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				svc := projectService.ServiceConfig
@@ -322,7 +322,7 @@ var _ = Describe("ProjectService", func() {
 					svcK8sConfig := config.SvcK8sConfig{}
 					svcK8sConfig.Service.Type = config.ServiceType(invalidType)
 
-					m, err = svcK8sConfig.ToMap()
+					m, err = svcK8sConfig.Map()
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -834,7 +834,7 @@ var _ = Describe("ProjectService", func() {
 
 			JustBeforeEach(func() {
 				svcK8sConfig.Workload.ImagePull.Policy = policy
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				extensions[config.K8SExtensionKey] = m
@@ -899,7 +899,7 @@ var _ = Describe("ProjectService", func() {
 
 			JustBeforeEach(func() {
 				projectService.SvcK8sConfig.Workload.RestartPolicy = policy
-				m, err := projectService.SvcK8sConfig.ToMap()
+				m, err := projectService.SvcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				svc := projectService.ServiceConfig

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.ImagePull.Secret = "my-pp-secret"
 
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{
@@ -157,7 +157,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.ServiceAccountName = "my-service-account"
 
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{
@@ -1857,7 +1857,7 @@ var _ = Describe("Transform", func() {
 					svcK8sConfig.Workload.ReadinessProbe.Type = config.ProbeTypeExec.String()
 					svcK8sConfig.Workload.ReadinessProbe.Exec.Command = []string{"hello world"}
 
-					ext, err := svcK8sConfig.ToMap()
+					ext, err := svcK8sConfig.Map()
 					Expect(err).NotTo(HaveOccurred())
 					projectService.Extensions = map[string]interface{}{
 						config.K8SExtensionKey: ext,
@@ -1876,7 +1876,7 @@ var _ = Describe("Transform", func() {
 				JustBeforeEach(func() {
 					svcK8sConfig := config.SvcK8sConfig{}
 					svcK8sConfig.Workload.LivenessProbe.Type = config.ProbeTypeNone.String()
-					m, err := svcK8sConfig.ToMap()
+					m, err := svcK8sConfig.Map()
 
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1975,7 +1975,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Resource.Memory = "10Mi"
 
-				ext, err := svcK8sConfig.ToMap()
+				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -1995,7 +1995,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Resource.MaxMemory = "10M"
 
-				ext, err := svcK8sConfig.ToMap()
+				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2015,7 +2015,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Resource.CPU = "0.1"
 
-				ext, err := svcK8sConfig.ToMap()
+				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2035,7 +2035,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Resource.MaxCPU = "0.5"
 
-				ext, err := svcK8sConfig.ToMap()
+				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 				projectService.Extensions = map[string]interface{}{
 					config.K8SExtensionKey: ext,
@@ -2061,7 +2061,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.PodSecurity.RunAsUser = &runAsUser
 
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
@@ -2083,7 +2083,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.PodSecurity.RunAsGroup = &runAsGroup
 
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}
@@ -2105,7 +2105,7 @@ var _ = Describe("Transform", func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.PodSecurity.FsGroup = &fsGroup
 
-				m, err := svcK8sConfig.ToMap()
+				m, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
 				projectService.Extensions = map[string]interface{}{config.K8SExtensionKey: m}

--- a/pkg/kev/init.go
+++ b/pkg/kev/init.go
@@ -167,7 +167,10 @@ func (r *InitRunner) CreateManifestAndEnvironmentOverrides(sources *Sources) err
 		return err
 	}
 
-	r.manifest.MintEnvironments(r.config.Envs)
+	if err := r.manifest.MintEnvironments(r.config.Envs); err != nil {
+		initStepError(r.UI, sg.Add(""), initStepCreateDeploymentEnvs, err)
+		return err
+	}
 
 	if err := r.eventHandler(PostCreateManifest, r); err != nil {
 		return newEventError(err, PostCreateManifest)
@@ -231,6 +234,7 @@ func createInitWritableResults(workingDir string, manifest *Manifest, skManifest
 		WriterTo: manifest,
 		FilePath: path.Join(workingDir, ManifestFilename),
 	})
+
 	out = append(out, manifest.Environments.toWritableResults()...)
 
 	if skManifest != nil {

--- a/pkg/kev/init_errors.go
+++ b/pkg/kev/init_errors.go
@@ -31,6 +31,7 @@ const (
 	initStepComposeSource
 	initStepParsingComposeConfig
 	initStepGenerateManifest
+	initStepCreateDeploymentEnvs
 	initStepValidatingSources
 	initStepUpdateSkaffold
 	initStepCreateSkaffold
@@ -66,6 +67,10 @@ to double check your compose source(s) are valid.
 
 	initStepGenerateManifest: {
 		Error: "Cannot create manifest using compose source files!",
+	},
+
+	initStepCreateDeploymentEnvs: {
+		Error: "Cannot create the compose files for the requested deployment environments!",
 	},
 
 	initStepValidatingSources: {

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -30,15 +30,15 @@ import (
 
 var _ = Describe("Reconcile", func() {
 	var (
-		hook          *test.Hook
-		loggedMsgs    string
-		workingDir    string
-		source        *kev.ComposeProject
-		overrideFiles []string
-		override      *kev.ComposeProject
-		manifest      *kev.Manifest
-		env           *kev.Environment
-		mErr          error
+		hook           *test.Hook
+		loggedMessages string
+		workingDir     string
+		source         *kev.ComposeProject
+		overrideFiles  []string
+		override       *kev.ComposeProject
+		manifest       *kev.Manifest
+		env            *kev.Environment
+		mErr           error
 	)
 
 	JustBeforeEach(func() {
@@ -59,7 +59,7 @@ var _ = Describe("Reconcile", func() {
 		env, err = manifest.GetEnvironment("dev")
 		Expect(err).NotTo(HaveOccurred())
 
-		loggedMsgs = testutil.GetLoggedMsgs(hook)
+		loggedMessages = testutil.GetLoggedMsgs(hook)
 	})
 
 	JustAfterEach(func() {
@@ -160,10 +160,10 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("3.7"))
-				Expect(loggedMsgs).To(ContainSubstring(env.GetVersion()))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("3.7"))
+				Expect(loggedMessages).To(ContainSubstring(env.GetVersion()))
 			})
 
 			It("should not error", func() {
@@ -192,9 +192,9 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("wordpress"))
-				Expect(loggedMsgs).To(ContainSubstring("removed"))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("wordpress"))
+				Expect(loggedMessages).To(ContainSubstring("removed"))
 			})
 
 			It("should not error", func() {
@@ -256,21 +256,8 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should configure the added service extension value defaults", func() {
-					expected, err := newDefaultServiceExtensions("wordpress", config.SvcK8sConfig{
-						Service: config.Service{
-							Type: config.ClusterIPService,
-						},
-						Workload: config.Workload{
-							Resource: config.Resource{
-								CPU:       "0.1",
-								MaxCPU:    "0.5",
-								Memory:    "10Mi",
-								MaxMemory: "500Mi",
-							},
-						},
-					})
+					expected, err := newMinifiedServiceExtensions("wordpress")
 					Expect(err).NotTo(HaveOccurred())
-
 					Expect(env.GetServices()[1].Extensions).To(Equal(expected))
 				})
 
@@ -283,9 +270,9 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should create a change summary", func() {
-					Expect(loggedMsgs).To(ContainSubstring(env.Name))
-					Expect(loggedMsgs).To(ContainSubstring("added"))
-					Expect(loggedMsgs).To(ContainSubstring("wordpress"))
+					Expect(loggedMessages).To(ContainSubstring(env.Name))
+					Expect(loggedMessages).To(ContainSubstring("added"))
+					Expect(loggedMessages).To(ContainSubstring("wordpress"))
 				})
 
 				It("should not error", func() {
@@ -299,23 +286,14 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should configure parse config into extensions", func() {
-					expected, err := newDefaultServiceExtensions("wordpress", config.SvcK8sConfig{
+					expected, err := newMinifiedServiceExtensions("wordpress", config.SvcK8sConfig{
 						Workload: config.Workload{
 							Replicas: 3,
-							Resource: config.Resource{
-								CPU:       "0.25",
-								MaxCPU:    "0.25",
-								Memory:    "20Mi",
-								MaxMemory: "50Mi",
-							},
-						},
-						Service: config.Service{
-							Type: config.ClusterIPService,
 						},
 					})
 					Expect(err).NotTo(HaveOccurred())
 
-					k8s, err := config.ParseSvcK8sConfigFromMap(env.GetServices()[1].Extensions)
+					k8s, err := config.ParseSvcK8sConfigFromMap(env.GetServices()[1].Extensions, config.SkipValidation())
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(k8s.Workload.Replicas).To(Equal(3))
@@ -329,19 +307,7 @@ var _ = Describe("Reconcile", func() {
 				})
 
 				It("should configure the added service extensions from healthcheck config", func() {
-					expected, err := newDefaultServiceExtensions("wordpress", config.SvcK8sConfig{
-						Workload: config.Workload{
-							Resource: config.Resource{
-								Memory:    "10Mi",
-								MaxMemory: "500Mi",
-								CPU:       "0.1",
-								MaxCPU:    "0.5",
-							},
-						},
-						Service: config.Service{
-							Type: config.ClusterIPService,
-						},
-					})
+					expected, err := newMinifiedServiceExtensions("wordpress")
 					Expect(err).NotTo(HaveOccurred())
 					expected["x-k8s"].(map[string]interface{})["workload"].(map[string]interface{})["livenessProbe"] = map[string]interface{}{
 						"type": config.ProbeTypeNone.String(),
@@ -377,9 +343,9 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("added"))
-				Expect(loggedMsgs).To(ContainSubstring("db_data"))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("added"))
+				Expect(loggedMessages).To(ContainSubstring("db_data"))
 			})
 
 			It("should not error", func() {
@@ -406,9 +372,9 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("removed"))
-				Expect(loggedMsgs).To(ContainSubstring("db_data"))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("removed"))
+				Expect(loggedMessages).To(ContainSubstring("db_data"))
 			})
 
 			It("should not error", func() {
@@ -437,11 +403,11 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("removed"))
-				Expect(loggedMsgs).To(ContainSubstring("db_data"))
-				Expect(loggedMsgs).To(ContainSubstring("added"))
-				Expect(loggedMsgs).To(ContainSubstring("mysql_data"))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("removed"))
+				Expect(loggedMessages).To(ContainSubstring("db_data"))
+				Expect(loggedMessages).To(ContainSubstring("added"))
+				Expect(loggedMessages).To(ContainSubstring("mysql_data"))
 			})
 
 			It("should not error", func() {
@@ -472,10 +438,10 @@ var _ = Describe("Reconcile", func() {
 			})
 
 			It("should create a change summary", func() {
-				Expect(loggedMsgs).To(ContainSubstring(env.Name))
-				Expect(loggedMsgs).To(ContainSubstring("removed"))
-				Expect(loggedMsgs).To(ContainSubstring("WORDPRESS_CACHE_USER"))
-				Expect(loggedMsgs).To(ContainSubstring("WORDPRESS_CACHE_PASSWORD"))
+				Expect(loggedMessages).To(ContainSubstring(env.Name))
+				Expect(loggedMessages).To(ContainSubstring("removed"))
+				Expect(loggedMessages).To(ContainSubstring("WORDPRESS_CACHE_USER"))
+				Expect(loggedMessages).To(ContainSubstring("WORDPRESS_CACHE_PASSWORD"))
 			})
 
 			It("should not error", func() {
@@ -571,21 +537,19 @@ var _ = Describe("Reconcile", func() {
 	})
 })
 
-func newDefaultServiceExtensions(_ string, svcK8sConfigs ...config.SvcK8sConfig) (map[string]interface{}, error) {
+func newMinifiedServiceExtensions(_ string, svcK8sConfigs ...config.SvcK8sConfig) (map[string]interface{}, error) {
+	livenessProbe := config.DefaultLivenessProbe()
 	k8s := config.SvcK8sConfig{
-		Disabled: false,
 		Workload: config.Workload{
-			LivenessProbe:         config.DefaultLivenessProbe(),
-			ReadinessProbe:        config.DefaultReadinessProbe(),
-			ServiceAccountName:    config.DefaultServiceAccountName,
-			Type:                  config.DefaultWorkload,
-			Replicas:              config.DefaultReplicaNumber,
-			RollingUpdateMaxSurge: config.DefaultRollingUpdateMaxSurge,
-			RestartPolicy:         config.DefaultRestartPolicy,
-			ImagePull: config.ImagePull{
-				Policy: config.DefaultImagePullPolicy,
+			LivenessProbe: config.LivenessProbe{
+				Type: livenessProbe.Type,
+				ProbeConfig: config.ProbeConfig{
+					Exec: config.ExecProbe{
+						Command: livenessProbe.Exec.Command,
+					},
+				},
 			},
-			Autoscale: config.AutoscaleWithDefaults(),
+			Replicas: config.DefaultReplicaNumber,
 		},
 	}
 
@@ -603,7 +567,5 @@ func newDefaultServiceExtensions(_ string, svcK8sConfigs ...config.SvcK8sConfig)
 		return nil, err
 	}
 
-	return map[string]interface{}{
-		config.K8SExtensionKey: m,
-	}, nil
+	return map[string]interface{}{config.K8SExtensionKey: m}, nil
 }

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -598,7 +598,7 @@ func newDefaultServiceExtensions(_ string, svcK8sConfigs ...config.SvcK8sConfig)
 		k8s = c
 	}
 
-	m, err := k8s.ToMap()
+	m, err := k8s.Map()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -224,7 +224,7 @@ func validateEnvExtensions(e *Environment, base *composeOverride) error {
 
 		baseSvcK8sCfg, err := config.ParseSvcK8sConfigFromMap(baseSvc.Extensions, config.SkipValidation())
 		if err != nil {
-			return errors.Wrapf(missingSvcErr, "when parsing service %s extensions in base override", baseSvc.Name)
+			return errors.Wrapf(missingSvcErr, "when parsing service %s extensions in base compose file", baseSvc.Name)
 		}
 
 		envSvcK8sCfg, err := config.ParseSvcK8sConfigFromMap(s.Extensions, config.SkipValidation())
@@ -250,7 +250,7 @@ func validateEnvExtensions(e *Environment, base *composeOverride) error {
 
 		baseVolK8sCfg, err := config.ParseVolK8sConfigFromMap(baseVol.Extensions)
 		if err != nil {
-			return errors.Wrapf(missingVolError, "when parsing vol %s extensions in base override", name)
+			return errors.Wrapf(missingVolError, "when parsing vol %s extensions in base compose file", name)
 		}
 
 		envVolK8sCfg, err := config.ParseVolK8sConfigFromMap(vol.Extensions)

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -378,7 +378,7 @@ func (m *Manifest) getSourcesOverride() *composeOverride {
 // most useful for users to configure immediately.
 func minifyK8sExtensionsToBaseAttributes(override *composeOverride) error {
 	for _, svc := range override.Services {
-		minifiedSvcExt, err := config.MinifySvcExtension(svc.Extensions)
+		minifiedSvcExt, err := config.MinifySvcK8sExtension(svc.Extensions)
 		if err != nil {
 			return err
 		}
@@ -386,7 +386,7 @@ func minifyK8sExtensionsToBaseAttributes(override *composeOverride) error {
 	}
 
 	for _, vol := range override.Volumes {
-		minifiedVolExt, err := config.MinifyVolExtension(vol.Extensions)
+		minifiedVolExt, err := config.MinifyVolK8sExtension(vol.Extensions)
 		if err != nil {
 			return err
 		}

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -126,7 +126,7 @@ func (m *Manifest) CalculateSourcesBaseOverride(opts ...BaseOverrideOpts) (*Mani
 
 // MintEnvironments create new environments based on candidate environments.
 // This includes an implicit sandbox environment that will always be created.
-func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
+func (m *Manifest) MintEnvironments(candidates []string) error {
 	m.UI.Header("Creating deployment environments...")
 	sg := m.UI.StepGroup()
 	defer sg.Done()
@@ -138,7 +138,11 @@ func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 		candidates = append([]string{SandboxEnv}, candidates...)
 	}
 
-	override := m.getSourcesOverride()
+	overrideTemplate := m.getSourcesOverride()
+	if err := minifyK8sExtensionsToBaseAttributes(overrideTemplate); err != nil {
+		return err
+	}
+
 	for _, env := range candidates {
 		envFilename := path.Join(m.getWorkingDir(), fmt.Sprintf(fileNameTemplate, GetManifestName(), env))
 		var step kmd.Step
@@ -148,14 +152,17 @@ func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
 			step = sg.Add(fmt.Sprintf("Creating the %s env file: %s", env, envFilename))
 		}
 
-		m.Environments = append(m.Environments, &Environment{
+		candidate := &Environment{
 			Name:     env,
-			override: override,
+			override: overrideTemplate,
 			File:     envFilename,
-		})
+		}
+
+		m.Environments = append(m.Environments, candidate)
 		step.Success()
 	}
-	return m
+
+	return nil
 }
 
 // GetEnvironmentFileNameTemplate returns environment file name template to match
@@ -186,7 +193,7 @@ func (m *Manifest) ReconcileConfig(envs ...string) (*Manifest, error) {
 	}
 
 	for _, e := range filteredEnvs {
-		if err := validateExtensions(e.override); err != nil {
+		if err := validateEnvExtensions(e, sourcesOverride); err != nil {
 			sg := m.UI.StepGroup()
 			defer sg.Done()
 			renderStepError(m.UI, sg.Add(""), renderStepReconcile, err)
@@ -203,17 +210,56 @@ func (m *Manifest) ReconcileConfig(envs ...string) (*Manifest, error) {
 	return m, nil
 }
 
-func validateExtensions(override *composeOverride) error {
-	for _, s := range override.Services {
-		_, err := config.ParseSvcK8sConfigFromMap(s.Extensions)
+func validateEnvExtensions(e *Environment, base *composeOverride) error {
+	for _, s := range e.GetServices() {
+		baseSvc, missingSvcErr := base.getService(s.Name)
+		if missingSvcErr != nil {
+			continue
+		}
+
+		baseSvcK8sCfg, err := config.ParseSvcK8sConfigFromMap(baseSvc.Extensions, config.SkipValidation())
 		if err != nil {
-			return errors.Wrapf(err, "when parsing service %s extensions", s.Name)
+			return errors.Wrapf(missingSvcErr, "when parsing service %s extensions in base override", baseSvc.Name)
+		}
+
+		envSvcK8sCfg, err := config.ParseSvcK8sConfigFromMap(s.Extensions, config.SkipValidation())
+		if err != nil {
+			return errors.Wrapf(missingSvcErr, "when parsing service %s extensions", s.Name)
+		}
+
+		mergedK8sSvcCfg, err := baseSvcK8sCfg.Merge(envSvcK8sCfg)
+		if err != nil {
+			return missingSvcErr
+		}
+
+		if err := mergedK8sSvcCfg.Validate(); err != nil {
+			return err
 		}
 	}
-	for name, vol := range override.Volumes {
-		_, err := config.ParseVolK8sConfigFromMap(vol.Extensions)
+
+	for name, vol := range e.GetVolumes() {
+		baseVol, missingVolError := base.getVolume(name)
+		if missingVolError != nil {
+			continue
+		}
+
+		baseVolK8sCfg, err := config.ParseVolK8sConfigFromMap(baseVol.Extensions)
 		if err != nil {
-			return errors.Wrapf(err, "when parsing vol %s extensions", name)
+			return errors.Wrapf(missingVolError, "when parsing vol %s extensions in base override", name)
+		}
+
+		envVolK8sCfg, err := config.ParseVolK8sConfigFromMap(vol.Extensions)
+		if err != nil {
+			return errors.Wrapf(missingVolError, "when parsing vol %s extensions", name)
+		}
+
+		mergedVolK8sCfg, err := baseVolK8sCfg.Merge(envVolK8sCfg)
+		if err != nil {
+			return missingVolError
+		}
+
+		if err := mergedVolK8sCfg.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -301,6 +347,16 @@ func (m *Manifest) GetSourcesFiles() []string {
 	return m.Sources.Files
 }
 
+// SourcesToComposeProject returns the manifests compose sources as a ComposeProject.
+func (m *Manifest) SourcesToComposeProject() (*ComposeProject, error) {
+	return m.Sources.toComposeProject()
+}
+
+func ManifestExistsForPath(manifestPath string) bool {
+	_, err := os.Stat(manifestPath)
+	return err == nil
+}
+
 // getWorkingDir gets the sources working directory.
 func (m *Manifest) getWorkingDir() string {
 	return m.Sources.getWorkingDir()
@@ -313,12 +369,24 @@ func (m *Manifest) getSourcesOverride() *composeOverride {
 	return override
 }
 
-// SourcesToComposeProject returns the manifests compose sources as a ComposeProject.
-func (m *Manifest) SourcesToComposeProject() (*ComposeProject, error) {
-	return m.Sources.toComposeProject()
-}
+// minifyK8sExtensionsToBaseAttributes removes all attributes except a selected few deemed
+// most useful for users to configure immediately.
+func minifyK8sExtensionsToBaseAttributes(override *composeOverride) error {
+	for _, svc := range override.Services {
+		minifiedSvcExt, err := config.MinifySvcExtension(svc.Extensions)
+		if err != nil {
+			return err
+		}
+		svc.Extensions[config.K8SExtensionKey] = minifiedSvcExt
+	}
 
-func ManifestExistsForPath(manifestPath string) bool {
-	_, err := os.Stat(manifestPath)
-	return err == nil
+	for _, vol := range override.Volumes {
+		minifiedVolExt, err := config.MinifyVolExtension(vol.Extensions)
+		if err != nil {
+			return err
+		}
+		vol.Extensions[config.K8SExtensionKey] = minifiedVolExt
+	}
+
+	return nil
 }

--- a/pkg/kev/render_errors.go
+++ b/pkg/kev/render_errors.go
@@ -29,7 +29,8 @@ type renderStepType uint
 const (
 	renderStepLoad renderStepType = iota
 	renderStepLoadSkaffold
-	renderStepReconcile
+	renderStepReconcileDetect
+	renderStepReconcileApply
 	renderStepReconcileWrite
 	renderStepRenderGeneral
 	renderStepValidatingSources
@@ -58,8 +59,12 @@ run the 'init' command with the '--skaffold' flag.
 		Error: "Encountered an error while validating sources!",
 	},
 
-	renderStepReconcile: {
+	renderStepReconcileDetect: {
 		Error: "Cannot detect project updates!",
+	},
+
+	renderStepReconcileApply: {
+		Error: "Cannot apply project updates!",
 	},
 
 	renderStepReconcileWrite: {

--- a/pkg/kev/sources.go
+++ b/pkg/kev/sources.go
@@ -55,7 +55,7 @@ func (s *Sources) CalculateBaseOverride(opts ...BaseOverrideOpts) error {
 			return err
 		}
 
-		m, err := k8sConf.ToMap()
+		m, err := k8sConf.Map()
 		if err != nil {
 			return err
 		}

--- a/pkg/kev/testdata/init-default/compose-yaml-src-ext/compose.yaml
+++ b/pkg/kev/testdata/init-default/compose-yaml-src-ext/compose.yaml
@@ -1,0 +1,21 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8.0.19
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+    x-k8s:
+      workload:
+        replicas: 10
+volumes:
+  db_data:
+    x-k8s:
+      size: 30Gi
+

--- a/pkg/kev/testdata/init-default/compose-yaml-src-ext/output.yaml
+++ b/pkg/kev/testdata/init-default/compose-yaml-src-ext/output.yaml
@@ -9,8 +9,8 @@ services:
             - echo
             - Define healthcheck command for service
           type: exec
-        replicas: 1
+        replicas: 10
 volumes:
   db_data:
     x-k8s:
-      size: 100Mi
+      size: 30Gi


### PR DESCRIPTION
This resolves #497 

- Minifies environment overrides on init - including overwrite values received from the sources.

- Applies a just in time configuration strategy by overlaying config info at the last minute to render the required k8s manifests.

Config info is used from:
- Sources compose config.
- Any sources' k8s extensions.
- Minified environment overrides.


