### PR TITLE
Improves skaffold manifest build artifacts detection with support for build strategy with CNB

### DIFF
--- a/pkg/kev/init.go
+++ b/pkg/kev/init.go
@@ -209,10 +209,7 @@ func (r *InitRunner) CreateOrUpdateSkaffoldManifest() (*SkaffoldManifest, error)
 		updateStep.Success()
 	case false:
 		createStep := sg.Add(fmt.Sprintf("Creating Skaffold config with deployment environment profiles at: %s", skPath))
-		if skManifest, err = NewSkaffoldManifest(envs, composeProject); err != nil {
-			initStepError(r.UI, createStep, initStepCreateSkaffold, err)
-			return nil, err
-		}
+		skManifest = NewSkaffoldManifest(envs, composeProject)
 		createStep.Success()
 	}
 

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -341,16 +341,6 @@ func (s *SkaffoldManifest) AddProfileIfNotPresent(p latest.Profile) {
 
 // SetBuildArtifacts detects build artifacts from the current project and adds `build` section to the manifest
 func (s *SkaffoldManifest) SetBuildArtifacts(analysis *Analysis, project *ComposeProject) error {
-
-	// There are at least 3 cases we should handle:
-	//
-	// 1) Dockerfile present and (optionally) docker images referenced in docker-compose file and/or detected by skaffold analysis (in existing k8s manifests if any)
-	// 	->  we set artifact as docker image with context (i.e. local docker build)
-	// 2) No Dockerfile detected in analysis and docker-compose references image (without context!)
-	//  - we shouldn't attempt to build as referenced image looks like pre-built image
-	// 3) No Dockerfile detected in analysis and docker-compose references image (with context!)
-	//  - we should build (as context is present) with `buildpacks` (as there is no Dockerfile)
-
 	artifacts := []*latest.Artifact{}
 
 	for context, image := range collectBuildArtifacts(analysis, project) {
@@ -378,6 +368,19 @@ func (s *SkaffoldManifest) SetBuildArtifacts(analysis *Analysis, project *Compos
 // collectBuildArtfacts returns a map of build contexts to corresponding image names
 func collectBuildArtifacts(analysis *Analysis, project *ComposeProject) map[string]string {
 	buildArtifacts := map[string]string{}
+
+	// There are at least 4 cases we should handle:
+	//
+	// 1) Dockerfile detected in analysis and/or docker images referenced in docker-compose file
+	// 	  * local docker build -> build artifact as docker image with context
+	// 2) No Dockerfile detected in analysis and docker-compose references image (without context!)
+	//    * no build required -> referenced image looks like pre-built image
+	// 3) No Dockerfile detected in analysis and docker-compose references image (with context!)
+	//    * buildpacks -> context is present
+	// 4) [Edge case] No Dockerfile detected in analysis and docker-compose doesn't reference an image
+	//    * inject image name to be the compose service name and build context set to project directory
+	// 		in the docker-compose.yaml
+	//    * buildpacks -> image or context present
 
 	// @step Skaffold analysis is present and Dockerfiles have been detected
 	if analysis != nil && analysis.Dockerfiles != nil {

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -369,18 +369,14 @@ func (s *SkaffoldManifest) SetBuildArtifacts(analysis *Analysis, project *Compos
 func collectBuildArtifacts(analysis *Analysis, project *ComposeProject) map[string]string {
 	buildArtifacts := map[string]string{}
 
-	// There are at least 4 cases we should handle:
+	// There are at least 3 cases we should handle:
 	//
 	// 1) Dockerfile detected in analysis and/or docker images referenced in docker-compose file
-	// 	  * local docker build -> build artifact as docker image with context
+	// 	  * local docker build -> build artifact as docker image with build context
 	// 2) No Dockerfile detected in analysis and docker-compose references image (without context!)
 	//    * no build required -> referenced image looks like pre-built image
 	// 3) No Dockerfile detected in analysis and docker-compose references image (with context!)
 	//    * buildpacks -> context is present
-	// 4) [Edge case] No Dockerfile detected in analysis and docker-compose doesn't reference an image
-	//    * inject image name to be the compose service name and build context set to project directory
-	// 		in the docker-compose.yaml
-	//    * buildpacks -> image or context present
 
 	// @step Skaffold analysis is present and Dockerfiles have been detected
 	if analysis != nil && analysis.Dockerfiles != nil {
@@ -569,9 +565,11 @@ func RunSkaffoldDev(ctx context.Context, out io.Writer, skaffoldFile string, pro
 	}
 
 	runCtx, cfg, err := runContext(skaffoldOpts, profiles, out)
+	if err != nil {
+		return errors.Wrap(err, "Skaffold dev failed")
+	}
 
 	r, err := runner.NewForConfig(runCtx)
-
 	if err != nil {
 		return errors.Wrap(err, "Skaffold dev failed")
 	}

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -44,16 +44,14 @@ var _ = Describe("Skaffold", func() {
 	Describe("NewSkaffoldManifest", func() {
 		var (
 			skaffoldManifest *kev.SkaffoldManifest
-			err              error
 		)
 
 		JustBeforeEach(func() {
-			skaffoldManifest, err = kev.NewSkaffoldManifest([]string{}, &kev.ComposeProject{})
+			skaffoldManifest = kev.NewSkaffoldManifest([]string{}, &kev.ComposeProject{})
 		})
 
 		It("generates skaffold config for the project", func() {
 			Expect(skaffoldManifest).ToNot(BeNil())
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -279,7 +277,6 @@ var _ = Describe("Skaffold", func() {
 			project          *kev.ComposeProject
 			analysis         *kev.Analysis
 			changed          bool
-			err              error
 		)
 
 		BeforeEach(func() {
@@ -318,13 +315,12 @@ var _ = Describe("Skaffold", func() {
 		})
 
 		JustBeforeEach(func() {
-			changed, err = skaffoldManifest.UpdateBuildArtifacts(analysis, project)
+			changed = skaffoldManifest.UpdateBuildArtifacts(analysis, project)
 		})
 
 		When("list of detected build artefacts had not changed", func() {
 			It("doesn't update build artefacts in skaffold manifest", func() {
 				Expect(changed).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
 				Expect(skaffoldManifest.Build.Artifacts).To(HaveLen(2))
 
 				images := []string{}
@@ -343,7 +339,6 @@ var _ = Describe("Skaffold", func() {
 
 			It("updates build artefacts in skaffold manifest", func() {
 				Expect(changed).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
 				Expect(skaffoldManifest.Build.Artifacts).To(HaveLen(2))
 
 				images := []string{}

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -579,7 +579,7 @@ var _ = Describe("Skaffold", func() {
 
 				})
 
-				When("Docker Compose project doens't have services referencing images with build contexts", func() {
+				When("Docker Compose project doesn't have services referencing images with build contexts", func() {
 					image := "quay.io/org/myimage:latest"
 
 					BeforeEach(func() {


### PR DESCRIPTION
Resolves #537 

This PR slightly modifies the way Skaffold build artifacts are detected, and as a result strategy used to build them.
By default a `local docker build` strategy is used, unless no Dockerfile has been detected and docker compose manifest (application stack representation) references docker images with a build context - this suggest that artefact build should still go ahead, however, as there is no Dockerfile present it should use CNB to do the build. 
