### PR TITLE
Set correct livenessProbe success threshold

### DIFF
--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -79,9 +79,6 @@ const (
 	// Default: 0.1, which is equivalent to 10% of CPU
 	DefaultResourceRequestCPU = "0.1"
 
-	// DefaultLivenessProbeType default probe type.
-	DefaultLivenessProbeType = "exec"
-
 	// DefaultProbeTimeout default 10s
 	DefaultProbeTimeout = "10s"
 
@@ -91,11 +88,11 @@ const (
 	// DefaultProbeInitialDelay default 1m (1 minute)
 	DefaultProbeInitialDelay = "1m"
 
-	// DefaultProbeRetries default 3. Number of retries for probe command
-	DefaultProbeRetries = 3
+	// DefaultProbeFailureThreshold default 3. Defines the failure threshold (number of retries) for the workload before giving up.
+	DefaultProbeFailureThreshold = 3
 
-	// DefaultSuccessThreshold default 1. Minimum consecutive successes for the probe to be considered successful
-	DefaultSuccessThreshold = 1
+	// DefaultProbeSuccessThreshold default 1. Minimum consecutive successes for the probe to be considered successful
+	DefaultProbeSuccessThreshold = 1
 
 	// DefaultProbeDisable default false. Enabled by default
 	DefaultProbeDisable = false

--- a/pkg/kev/config/defaults.go
+++ b/pkg/kev/config/defaults.go
@@ -91,8 +91,11 @@ const (
 	// DefaultProbeInitialDelay default 1m (1 minute)
 	DefaultProbeInitialDelay = "1m"
 
-	// DefaultProbeRetries default 3. Number of retries for liveness probe command
+	// DefaultProbeRetries default 3. Number of retries for probe command
 	DefaultProbeRetries = 3
+
+	// DefaultSuccessThreshold default 1. Minimum consecutive successes for the probe to be considered successful
+	DefaultSuccessThreshold = 1
 
 	// DefaultProbeDisable default false. Enabled by default
 	DefaultProbeDisable = false

--- a/pkg/kev/config/probes.go
+++ b/pkg/kev/config/probes.go
@@ -73,8 +73,8 @@ func DefaultLivenessProbe() LivenessProbe {
 			},
 			InitialDelay:     delay,
 			Period:           interval,
-			FailureThreshold: DefaultProbeRetries,
-			SuccessThreshold: DefaultSuccessThreshold,
+			FailureThreshold: DefaultProbeFailureThreshold,
+			SuccessThreshold: DefaultProbeSuccessThreshold,
 			Timeout:          timeout,
 		},
 	}
@@ -98,8 +98,8 @@ func DefaultReadinessProbe() ReadinessProbe {
 		ProbeConfig: ProbeConfig{
 			InitialDelay:     delay,
 			Period:           interval,
-			FailureThreshold: DefaultProbeRetries,
-			SuccessThreshold: DefaultSuccessThreshold,
+			FailureThreshold: DefaultProbeFailureThreshold,
+			SuccessThreshold: DefaultProbeSuccessThreshold,
 			Timeout:          timeout,
 		},
 	}

--- a/pkg/kev/config/probes.go
+++ b/pkg/kev/config/probes.go
@@ -74,6 +74,7 @@ func DefaultLivenessProbe() LivenessProbe {
 			InitialDelay:     delay,
 			Period:           interval,
 			FailureThreshold: DefaultProbeRetries,
+			SuccessThreshold: DefaultSuccessThreshold,
 			Timeout:          timeout,
 		},
 	}
@@ -98,6 +99,7 @@ func DefaultReadinessProbe() ReadinessProbe {
 			InitialDelay:     delay,
 			Period:           interval,
 			FailureThreshold: DefaultProbeRetries,
+			SuccessThreshold: DefaultSuccessThreshold,
 			Timeout:          timeout,
 		},
 	}
@@ -112,6 +114,7 @@ type ProbeConfig struct {
 	InitialDelay     time.Duration `yaml:"initialDelay,omitempty"`
 	Period           time.Duration `yaml:"period,omitempty"`
 	FailureThreshold int           `yaml:"failureThreshold,omitempty"`
+	SuccessThreshold int           `yaml:"successThreshold,omitempty"`
 	Timeout          time.Duration `yaml:"timeout,omitempty"`
 }
 

--- a/pkg/kev/converter/kubernetes/probes.go
+++ b/pkg/kev/converter/kubernetes/probes.go
@@ -10,6 +10,7 @@ import (
 )
 
 func LivenessProbeToV1Probe(lp config.LivenessProbe) (*v1.Probe, error) {
+	lp.SuccessThreshold = config.DefaultSuccessThreshold
 	return v1probe(lp.Type, lp.ProbeConfig)
 }
 
@@ -32,7 +33,7 @@ func v1probe(probeType string, pc config.ProbeConfig) (*v1.Probe, error) {
 		InitialDelaySeconds: int32(pc.InitialDelay.Seconds()),
 		TimeoutSeconds:      int32(pc.Timeout.Seconds()),
 		PeriodSeconds:       int32(pc.Period.Seconds()),
-		SuccessThreshold:    int32(pc.FailureThreshold),
+		SuccessThreshold:    int32(pc.SuccessThreshold),
 		FailureThreshold:    int32(pc.FailureThreshold),
 	}, nil
 }

--- a/pkg/kev/converter/kubernetes/probes.go
+++ b/pkg/kev/converter/kubernetes/probes.go
@@ -10,7 +10,7 @@ import (
 )
 
 func LivenessProbeToV1Probe(lp config.LivenessProbe) (*v1.Probe, error) {
-	lp.SuccessThreshold = config.DefaultSuccessThreshold
+	lp.SuccessThreshold = config.DefaultProbeSuccessThreshold
 	return v1probe(lp.Type, lp.ProbeConfig)
 }
 

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -1099,7 +1099,7 @@ var _ = Describe("ProjectService", func() {
 					PeriodSeconds:       10,
 					InitialDelaySeconds: 10,
 					FailureThreshold:    3,
-					SuccessThreshold:    3,
+					SuccessThreshold:    1,
 				})).To(BeEmpty())
 			})
 		})

--- a/pkg/kev/transform.go
+++ b/pkg/kev/transform.go
@@ -58,7 +58,7 @@ func augmentOrAddDeploy(x *ComposeProject) error {
 func augmentOrAddHealthCheck(x *ComposeProject) error {
 	var updated composego.Services
 	err := x.WithServices(x.ServiceNames(), func(svc composego.ServiceConfig) error {
-		check := createHealthCheck(svc.Name)
+		check := createHealthCheck()
 
 		if svc.HealthCheck != nil {
 			if err := mergo.Merge(&check, svc.HealthCheck, mergo.WithOverride); err != nil {
@@ -109,7 +109,7 @@ func createDeploy() composego.DeployConfig {
 }
 
 // createHealthCheck returns a healthcheck block with configured placeholders.
-func createHealthCheck(svcName string) composego.HealthCheckConfig {
+func createHealthCheck() composego.HealthCheckConfig {
 	testMsg := fmt.Sprintf(config.DefaultLivenessProbeCommand[1])
 	to, _ := time.ParseDuration(config.DefaultProbeTimeout)
 	iv, _ := time.ParseDuration(config.DefaultProbeInterval)
@@ -117,7 +117,7 @@ func createHealthCheck(svcName string) composego.HealthCheckConfig {
 	timeout := composego.Duration(to)
 	interval := composego.Duration(iv)
 	startPeriod := composego.Duration(sp)
-	retries := uint64(config.DefaultProbeRetries)
+	retries := uint64(config.DefaultProbeFailureThreshold)
 
 	return composego.HealthCheckConfig{
 		Test:        []string{"CMD", "echo", testMsg},


### PR DESCRIPTION
Resolves #544 

- Introduces success threshold config for a `v1Probe`.
- Ensures the `LivenessProbe` success threshold is always set to `1`.