### PR TITLE
Handle ingress with kubernetes cluster defaults

### DIFF
--- a/pkg/kev/config/service.go
+++ b/pkg/kev/config/service.go
@@ -88,7 +88,7 @@ func inferServiceTypeFromComposeValue(v string) (ServiceType, error) {
 	case "nodeport":
 		return NodePortService, nil
 	case "loadbalancer":
-		return NodePortService, nil
+		return LoadBalancerService, nil
 	case "headless":
 		return HeadlessService, nil
 	case "none":

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -116,7 +116,7 @@ func (p *ProjectService) nodePort() int32 {
 
 // exposeService tells whether service for project component should be exposed
 func (p *ProjectService) exposeService() (string, error) {
-	val := p.SvcK8sConfig.Service.Expose.Domain
+	val := strings.TrimSpace(p.SvcK8sConfig.Service.Expose.Domain)
 
 	if val == "" && p.tlsSecretName() != "" {
 		return "", fmt.Errorf("service can't have TLS secret name when it hasn't been exposed")

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -51,7 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const DefaultIngressBackendMarker = "default"
+const DefaultIngressBackendKeyword = "default"
 
 // Kubernetes transformer
 type Kubernetes struct {
@@ -654,7 +654,7 @@ func (k *Kubernetes) initIngress(projectService ProjectService, port int32) *net
 		Spec: networkingv1beta1.IngressSpec{},
 	}
 
-	if hasDefaultIngressBackendMarker(hosts) {
+	if hasDefaultIngressBackendKeyword(hosts) {
 		ingress.Spec.Rules = []networkingv1beta1.IngressRule{
 			createIngressRule("", "", projectService.Name, port),
 		}

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -655,8 +655,11 @@ func (k *Kubernetes) initIngress(projectService ProjectService, port int32) *net
 	}
 
 	if hasDefaultIngressBackendKeyword(hosts) {
-		ingress.Spec.Rules = []networkingv1beta1.IngressRule{
-			createIngressRule("", "", projectService.Name, port),
+		ingress.Spec.Backend = &networkingv1beta1.IngressBackend{
+			ServiceName: projectService.Name,
+			ServicePort: intstr.IntOrString{
+				IntVal: port,
+			},
 		}
 		return ingress
 	}

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -734,7 +734,7 @@ var _ = Describe("Transform", func() {
 	Describe("initIngress", func() {
 		port := int32(1234)
 
-		When("project service extension instructing to expose the k8s service is specified as empty string", func() {
+		When("project service extension exposing the k8s service using an empty string", func() {
 			BeforeEach(func() {
 				projectService.SvcK8sConfig.Service.Expose.Domain = ""
 			})
@@ -744,7 +744,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service", func() {
+		When("project service extension exposing the k8s service", func() {
 			domain := "domain.name"
 			ingressAnnotations := map[string]string{
 				"kubernetes.io/ingress.class":    "external",
@@ -795,7 +795,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service", func() {
+		When("project service extension exposing the k8s service using a domain name", func() {
 			BeforeEach(func() {
 				projectService.SvcK8sConfig.Service.Expose.Domain = "domain.name"
 			})
@@ -813,7 +813,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service is specified as `domain.name`", func() {
+		When("project service extension exposing the k8s service using a domain with a path", func() {
 			domain := "domain.name"
 			path := "path"
 
@@ -833,7 +833,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service is specified as comma separated list of domain names", func() {
+		When("project service extension exposing the k8s service using a comma separated list of domain names", func() {
 			domains := []string{
 				"domain.name",
 				"another.domain.name",
@@ -850,7 +850,19 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service", func() {
+		When("project service extension exposing the k8s service using a default ingress backend", func() {
+			BeforeEach(func() {
+				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendMarker
+			})
+
+			It("creates a single rule without a host in the initialised Ingress", func() {
+				ingress := k.initIngress(projectService, port)
+				Expect(ingress.Spec.Rules).To(HaveLen(1))
+				Expect(ingress.Spec.Rules[0].Host).To(HaveLen(0))
+			})
+		})
+
+		When("project service extension instructing to expose the k8s service with domain and annotations", func() {
 			ingressAnnotations := map[string]string{
 				"kubernetes.io/ingress.class":    "external",
 				"cert-manager.io/cluster-issuer": "prod-le-dns01",
@@ -882,6 +894,18 @@ var _ = Describe("Transform", func() {
 						SecretName: "my-tls-secret",
 					},
 				}))
+			})
+		})
+
+		When("TLS secret name was specified via extension for service exposed with default ingress backend", func() {
+			BeforeEach(func() {
+				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendMarker
+				projectService.SvcK8sConfig.Service.Expose.TlsSecret = "my-tls-secret"
+			})
+
+			It("does not create a TLS object it in the ingress spec", func() {
+				ing := k.initIngress(projectService, port)
+				Expect(ing.Spec.TLS).To(HaveLen(0))
 			})
 		})
 	})

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -855,10 +855,11 @@ var _ = Describe("Transform", func() {
 				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendKeyword
 			})
 
-			It("creates a single rule without a host in the initialised Ingress", func() {
+			It("creates a default backend in the initialised Ingress with no rules`", func() {
 				ingress := k.initIngress(projectService, port)
-				Expect(ingress.Spec.Rules).To(HaveLen(1))
-				Expect(ingress.Spec.Rules[0].Host).To(HaveLen(0))
+				Expect(ingress.Spec.Backend.ServiceName).To(Equal(projectService.Name))
+				Expect(ingress.Spec.Backend.ServicePort.IntVal).To(Equal(port))
+				Expect(ingress.Spec.Rules).To(HaveLen(0))
 			})
 		})
 
@@ -903,7 +904,7 @@ var _ = Describe("Transform", func() {
 				projectService.SvcK8sConfig.Service.Expose.TlsSecret = "my-tls-secret"
 			})
 
-			It("does not create a TLS object it in the ingress spec", func() {
+			It("does not create a TLS object in the ingress spec", func() {
 				ing := k.initIngress(projectService, port)
 				Expect(ing.Spec.TLS).To(HaveLen(0))
 			})

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -852,7 +852,7 @@ var _ = Describe("Transform", func() {
 
 		When("project service extension exposing the k8s service using a default ingress backend", func() {
 			BeforeEach(func() {
-				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendMarker
+				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendKeyword
 			})
 
 			It("creates a single rule without a host in the initialised Ingress", func() {
@@ -899,7 +899,7 @@ var _ = Describe("Transform", func() {
 
 		When("TLS secret name was specified via extension for service exposed with default ingress backend", func() {
 			BeforeEach(func() {
-				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendMarker
+				projectService.SvcK8sConfig.Service.Expose.Domain = DefaultIngressBackendKeyword
 				projectService.SvcK8sConfig.Service.Expose.TlsSecret = "my-tls-secret"
 			})
 

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -953,10 +953,10 @@ func volumeByNameAndFormat(name string, formatter func(string) string, volumes c
 	return composego.VolumeConfig{}
 }
 
-// hasDefaultIngressBackendMarker determines whether the host value list contains the marker used to create
+// hasDefaultIngressBackendKeyword determines whether the host value list contains the keyword used to create
 // a default backend ingress.
-func hasDefaultIngressBackendMarker(v []string) bool {
-	return strings.Contains(strings.Join(v, ""), DefaultIngressBackendMarker)
+func hasDefaultIngressBackendKeyword(v []string) bool {
+	return strings.Contains(strings.Join(v, ""), DefaultIngressBackendKeyword)
 }
 
 // createIngressRule creates an ingress rule using a set of parameters.


### PR DESCRIPTION
Resolves #550

- Exposed service with keyword `default` will use the default ingress backend.
- Exposed service with keyword `default` will not create a TLS ingress spec as per [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls).