### PR TITLE
Added workload pod annotations to rendered manifests.

### DIFF
--- a/docs/reference/config-example.md
+++ b/docs/reference/config-example.md
@@ -19,6 +19,9 @@ services:                                                # compose services sect
           domain:                                        # Default: "" (no ingress). Possible options: "" | "default" | domain.com,otherdomain.com (comma separated domain names). When with "default" or domain name(s) - it'll generate an ingress object and expose service externally.
           tlsSecret:                                     # Default: "" (no tls). Kubernetes secret name where certs will be loaded from.
       workload:                                          # K8s workload configuration (only required if values are overridden)
+        annotations:                                     # Default: nil. A key/value map to attach metadata to a K8s Pod Spec in a deployable object, e.g. Deployment, StatefulSet, etc... 
+          key-one: value one
+          key-two: value two
         autoscale:                                       # Configures an application for auto-scaling.
           maxReplicas: 0                                 # Default: 0. Number of replicas to autoscale to.
           cpuThreshold: 70                               # Default: 70. The CPU utilisation threshold.

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -53,7 +53,30 @@ services:
 
 # → Workload
 
-This configuration group contains Kubernetes `workload` specific settings. Configuration parameters can be individually defined for each application stack component.
+This configuration group contains Kubernetes `workload` specific settings. Configuration parameters can be individually defined for each application stack component. 
+
+## workload.annotations
+
+A key/value map to attach metadata to a K8s Pod spec in a deployable object, e.g., Deployment, StatefulSet, etc... See official K8s [documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
+
+### Default: nil (not specified)
+
+### Possible options: key/value map with a string key and string value.
+
+> workload.annotations:
+```yaml
+version: 3.7
+services:
+  my-service:
+    x-k8s:
+      workload:
+        annotations:
+          key1: value 1
+          key2: value 2
+          key3: |
+            value 3 and value 4 
+...
+```
 
 ## workload.imagePull
 

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -419,7 +419,7 @@ type Workload struct {
 	Replicas              int               `yaml:"replicas" validate:""`
 	ServiceAccountName    string            `yaml:"serviceAccountName,omitempty" validate:"subdomainIfAny"`
 	RollingUpdateMaxSurge int               `yaml:"rollingUpdateMaxSurge,omitempty" validate:""`
-	PodAnnotations        map[string]string `yaml:"annotations,omitempty"`
+	Annotations           map[string]string `yaml:"annotations,omitempty"`
 	LivenessProbe         LivenessProbe     `yaml:"livenessProbe" validate:"required"`
 	ReadinessProbe        ReadinessProbe    `yaml:"readinessProbe,omitempty"`
 	RestartPolicy         RestartPolicy     `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -415,17 +415,18 @@ func validateDNSSubdomainNameIfAny(fl validator.FieldLevel) bool {
 
 // Workload holds all the workload-related k8s configurations.
 type Workload struct {
-	Type                  WorkloadType   `yaml:"type,omitempty" validate:"workloadType"`
-	Replicas              int            `yaml:"replicas" validate:""`
-	ServiceAccountName    string         `yaml:"serviceAccountName,omitempty" validate:"subdomainIfAny"`
-	RollingUpdateMaxSurge int            `yaml:"rollingUpdateMaxSurge,omitempty" validate:""`
-	LivenessProbe         LivenessProbe  `yaml:"livenessProbe" validate:"required"`
-	ReadinessProbe        ReadinessProbe `yaml:"readinessProbe,omitempty"`
-	RestartPolicy         RestartPolicy  `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`
-	ImagePull             ImagePull      `yaml:"imagePull,omitempty"`
-	Resource              Resource       `yaml:"resource,omitempty"`
-	Autoscale             Autoscale      `yaml:"autoscale,omitempty"`
-	PodSecurity           PodSecurity    `yaml:"podSecurity,omitempty"`
+	Type                  WorkloadType      `yaml:"type,omitempty" validate:"workloadType"`
+	Replicas              int               `yaml:"replicas" validate:""`
+	ServiceAccountName    string            `yaml:"serviceAccountName,omitempty" validate:"subdomainIfAny"`
+	RollingUpdateMaxSurge int               `yaml:"rollingUpdateMaxSurge,omitempty" validate:""`
+	PodAnnotations        map[string]string `yaml:"annotations,omitempty"`
+	LivenessProbe         LivenessProbe     `yaml:"livenessProbe" validate:"required"`
+	ReadinessProbe        ReadinessProbe    `yaml:"readinessProbe,omitempty"`
+	RestartPolicy         RestartPolicy     `yaml:"restartPolicy,omitempty" validate:"restartPolicy"`
+	ImagePull             ImagePull         `yaml:"imagePull,omitempty"`
+	Resource              Resource          `yaml:"resource,omitempty"`
+	Autoscale             Autoscale         `yaml:"autoscale,omitempty"`
+	PodSecurity           PodSecurity       `yaml:"podSecurity,omitempty"`
 }
 
 type Resource struct {

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -139,7 +139,7 @@ func (p *ProjectService) tlsSecretName() string {
 	return p.SvcK8sConfig.Service.Expose.TlsSecret
 }
 
-// ingressAnnotations returns the ingress podAnnotations for exposed service (to be used in the ingress configuration)
+// ingressAnnotations returns the ingress annotations for exposed service (to be used in the ingress configuration)
 func (p *ProjectService) ingressAnnotations() map[string]string {
 	annotations := p.SvcK8sConfig.Service.Expose.IngressAnnotations
 	if len(annotations) == 0 {

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -51,7 +51,7 @@ func (p *ProjectService) enabled() bool {
 
 // podAnnotations returns the workload pod annotations
 func (p *ProjectService) podAnnotations() map[string]string {
-	out := p.SvcK8sConfig.Workload.PodAnnotations
+	out := p.SvcK8sConfig.Workload.Annotations
 	if len(out) == 0 {
 		out = map[string]string{}
 	}

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -49,6 +49,15 @@ func (p *ProjectService) enabled() bool {
 	return !p.SvcK8sConfig.Disabled
 }
 
+// podAnnotations returns the workload pod annotations
+func (p *ProjectService) podAnnotations() map[string]string {
+	out := p.SvcK8sConfig.Workload.PodAnnotations
+	if len(out) == 0 {
+		out = map[string]string{}
+	}
+	return out
+}
+
 // replicas returns number of replicas for given project service
 func (p *ProjectService) replicas() int32 {
 	return int32(p.SvcK8sConfig.Workload.Replicas)
@@ -130,7 +139,7 @@ func (p *ProjectService) tlsSecretName() string {
 	return p.SvcK8sConfig.Service.Expose.TlsSecret
 }
 
-// ingressAnnotations returns the ingress annotations for exposed service (to be used in the ingress configuration)
+// ingressAnnotations returns the ingress podAnnotations for exposed service (to be used in the ingress configuration)
 func (p *ProjectService) ingressAnnotations() map[string]string {
 	annotations := p.SvcK8sConfig.Service.Expose.IngressAnnotations
 	if len(annotations) == 0 {

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1339,10 +1339,10 @@ func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, err
 			})
 		case "pod":
 			// Selects a field of the pod
-			// supported paths: metadata.name, metadata.namespace, metadata.labels, metadata.podAnnotations,
+			// supported paths: metadata.name, metadata.namespace, metadata.labels, metadata.annotations,
 			// 					spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 			paths := []string{
-				"metadata.name", "metadata.namespace", "metadata.labels", "metadata.podAnnotations",
+				"metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations",
 				"spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP", "status.podIPs",
 			}
 
@@ -1684,7 +1684,7 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 	// @step configure capabilities
 	capabilities := k.configCapabilities(projectService)
 
-	// @step configure podAnnotations
+	// @step configure annotations
 	annotations := configAnnotations(projectService.Labels)
 
 	// @step fillTemplate function will fill the pod template with the values calculated from config

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -502,7 +502,7 @@ func (k *Kubernetes) initDeployment(projectService ProjectService) *v1apps.Deplo
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: meta.ObjectMeta{
-					Annotations: configAnnotations(projectService),
+					Annotations: configAnnotations(projectService.Labels, projectService.podAnnotations()),
 					Labels:      configLabels(projectService.Name),
 				},
 				Spec: podSpec,
@@ -576,7 +576,7 @@ func (k *Kubernetes) initStatefulSet(projectService ProjectService) *v1apps.Stat
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: meta.ObjectMeta{
-					Annotations: configAnnotations(projectService),
+					Annotations: configAnnotations(projectService.Labels, projectService.podAnnotations()),
 					Labels:      configLabels(projectService.Name),
 				},
 				Spec: podSpec,
@@ -620,7 +620,7 @@ func (k *Kubernetes) initJob(projectService ProjectService, replicas int) *v1bat
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: meta.ObjectMeta{
-					Annotations: configAnnotations(projectService),
+					Annotations: configAnnotations(projectService.Labels, projectService.podAnnotations()),
 					Labels:      configLabels(projectService.Name),
 				},
 				Spec: podSpec,
@@ -759,7 +759,7 @@ func (k *Kubernetes) initHpa(projectService ProjectService, target runtime.Objec
 		ObjectMeta: meta.ObjectMeta{
 			Name:        projectService.Name,
 			Labels:      configLabels(projectService.Name),
-			Annotations: configAnnotations(projectService),
+			Annotations: configAnnotations(projectService.Labels),
 		},
 		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
@@ -1339,10 +1339,10 @@ func (k *Kubernetes) configEnvs(projectService ProjectService) ([]v1.EnvVar, err
 			})
 		case "pod":
 			// Selects a field of the pod
-			// supported paths: metadata.name, metadata.namespace, metadata.labels, metadata.annotations,
+			// supported paths: metadata.name, metadata.namespace, metadata.labels, metadata.podAnnotations,
 			// 					spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
 			paths := []string{
-				"metadata.name", "metadata.namespace", "metadata.labels", "metadata.annotations",
+				"metadata.name", "metadata.namespace", "metadata.labels", "metadata.podAnnotations",
 				"spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP", "status.podIPs",
 			}
 
@@ -1503,7 +1503,7 @@ func (k *Kubernetes) initPod(projectService ProjectService) *v1.Pod {
 		ObjectMeta: meta.ObjectMeta{
 			Name:        projectService.Name,
 			Labels:      configLabels(projectService.Name),
-			Annotations: configAnnotations(projectService),
+			Annotations: configAnnotations(projectService.Labels, projectService.podAnnotations()),
 		},
 		Spec: k.initPodSpec(projectService),
 	}
@@ -1612,7 +1612,7 @@ func (k *Kubernetes) createService(serviceType config.ServiceType, projectServic
 		svc.Spec.Type = v1SvcType
 	}
 
-	svc.ObjectMeta.Annotations = configAnnotations(projectService)
+	svc.ObjectMeta.Annotations = configAnnotations(projectService.Labels)
 
 	return svc, nil
 }
@@ -1636,7 +1636,7 @@ func (k *Kubernetes) createHeadlessService(projectService ProjectService) *v1.Se
 	svc.Spec.Ports = servicePorts
 	svc.Spec.ClusterIP = "None"
 
-	svc.ObjectMeta.Annotations = configAnnotations(projectService)
+	svc.ObjectMeta.Annotations = configAnnotations(projectService.Labels)
 
 	return svc
 }
@@ -1668,7 +1668,7 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 	// @step add PVCs to objects
 	// Looping on the slice pvcs instead of `*objects = append(*objects, pvcs...)`
 	// because the type of objects and pvcs is different, but when doing append
-	// one element at a time it gets converted to runtime.Object for objects slice
+	// one element at a time it getfs converted to runtime.Object for objects slice
 	for _, p := range pvcs {
 		*objects = append(*objects, p)
 	}
@@ -1684,8 +1684,8 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 	// @step configure capabilities
 	capabilities := k.configCapabilities(projectService)
 
-	// @step configure annotations
-	annotations := configAnnotations(projectService)
+	// @step configure podAnnotations
+	annotations := configAnnotations(projectService.Labels)
 
 	// @step fillTemplate function will fill the pod template with the values calculated from config
 	fillTemplate := func(template *v1.PodTemplateSpec) error {

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -1668,7 +1668,7 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 	// @step add PVCs to objects
 	// Looping on the slice pvcs instead of `*objects = append(*objects, pvcs...)`
 	// because the type of objects and pvcs is different, but when doing append
-	// one element at a time it getfs converted to runtime.Object for objects slice
+	// one element at a time it gets converted to runtime.Object for objects slice
 	for _, p := range pvcs {
 		*objects = append(*objects, p)
 	}

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -536,7 +536,7 @@ var _ = Describe("Transform", func() {
 		Context("for project service configured with pod annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodAnnotations = map[string]string{"key1": "value1"}
+				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
 				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
@@ -670,7 +670,7 @@ var _ = Describe("Transform", func() {
 		Context("for project service configured with pod annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodAnnotations = map[string]string{"key1": "value1"}
+				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
 				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
@@ -781,7 +781,7 @@ var _ = Describe("Transform", func() {
 		Context("for project service configured with pod annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
-				svcK8sConfig.Workload.PodAnnotations = map[string]string{"key1": "value1"}
+				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
 				ext, err := svcK8sConfig.Map()
 				Expect(err).NotTo(HaveOccurred())
 
@@ -935,7 +935,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		When("project service extension instructing to expose the k8s service with domain and podAnnotations", func() {
+		When("project service extension instructing to expose the k8s service with domain and ingress annotations", func() {
 			ingressAnnotations := map[string]string{
 				"kubernetes.io/ingress.class":    "external",
 				"cert-manager.io/cluster-issuer": "prod-le-dns01",

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		Context("for project service configured with pod annotations", func() {
+		Context("for project service configured with annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
@@ -667,7 +667,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		Context("for project service configured with pod annotations", func() {
+		Context("for project service configured with annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
@@ -778,7 +778,7 @@ var _ = Describe("Transform", func() {
 			})
 		})
 
-		Context("for project service configured with pod annotations", func() {
+		Context("for project service configured with annotations", func() {
 			BeforeEach(func() {
 				svcK8sConfig := config.DefaultSvcK8sConfig()
 				svcK8sConfig.Workload.Annotations = map[string]string{"key1": "value1"}
@@ -946,7 +946,7 @@ var _ = Describe("Transform", func() {
 				projectService.SvcK8sConfig.Service.Expose.Domain = "domain.name"
 			})
 
-			It("initialises Ingress with configured ingress podAnnotations", func() {
+			It("initialises Ingress with configured ingress annotations", func() {
 				ingress := k.initIngress(projectService, port)
 				Expect(ingress.ObjectMeta.Annotations).To(Equal(ingressAnnotations))
 			})

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -575,14 +575,16 @@ func configAllLabels(projectService ProjectService) map[string]string {
 	return base
 }
 
-// configAnnotations configures annotations - they are effectively compose project service labels,
+// configAnnotations creates annotations to be used where they are required,
 // @orig: https://github.com/kubernetes/kompose/blob/master/pkg/transformer/utils.go#L152
-func configAnnotations(projectService ProjectService) map[string]string {
-	annotations := map[string]string{}
-	for key, value := range projectService.Labels {
-		annotations[key] = value
+func configAnnotations(src ...map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, m := range src {
+		for key, val := range m {
+			out[key] = val
+		}
 	}
-	return annotations
+	return out
 }
 
 // parseIngressPath parses the path for ingress.

--- a/pkg/kev/converter/kubernetes/utils_test.go
+++ b/pkg/kev/converter/kubernetes/utils_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Utils", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			projectService.SvcK8sConfig.Workload.PodAnnotations = map[string]string{
+			projectService.SvcK8sConfig.Workload.Annotations = map[string]string{
 				"info.kev.io/annotation1": "app/role/value1",
 				"info.kev.io/annotation-db": `|
 {{- with secret "database/creds/db-app" -}}


### PR DESCRIPTION
Resolves #562 

- Adds annotations to rendered manifests as per configured workload annotations.
- Updates the documentation to include annotations config.

Example rendered deployment:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    service: wordpress
  name: wordpress
spec:
  replicas: 25
  selector:
    matchLabels:
      service: wordpress
  strategy:
  ...
  template:
    metadata:
      annotations:
        hello: world
      creationTimestamp: null
      labels:
        network/default: "true"
        service: wordpress
    spec:
       ...
status: {}
```