### PR TITLE
Bug fix: reconcile a "create" change with a new extension map.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,6 @@ github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8c
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
-github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
-github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-playground/validator/v10 v10.6.1 h1:W6TRDXt4WcWp4c4nf/G+6BkGdhiIo0k417gfr+V6u4I=
 github.com/go-playground/validator/v10 v10.6.1/go.mod h1:xm76BBt941f7yWdGnI2DVPFFg1UK3YY04qifoXU3lOk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -613,9 +611,9 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
@@ -1032,8 +1030,7 @@ github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.15.2 h1:l77YT15o814C2qVL47NOyjV/6RbaP7kKdrvZnxQ3Org=
-github.com/onsi/ginkgo v1.15.2/go.mod h1:Dd6YFfwBW84ETqqtL0CPyPXillHgY6XhQH3uuCCTr/o=
+github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1046,8 +1043,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
-github.com/onsi/gomega v1.11.0 h1:+CqWgvj0OZycCaqclBD1pxKHAU+tOkHmQIWvDHq2aug=
-github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
@@ -1536,7 +1531,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
@@ -1669,7 +1663,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -1906,9 +1899,9 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -101,8 +101,9 @@ func (chg change) patchService(override *composeOverride) (string, error) {
 			return "", err
 		}
 
-		newValue.Extensions[config.K8SExtensionKey] = minified
-		override.Services = append(override.Services, newValue)
+		override.Services = append(override.Services, ServiceConfig{Name: newValue.Name, Extensions: map[string]interface{}{
+			config.K8SExtensionKey: minified,
+		}})
 
 		msg := fmt.Sprintf("added service: %s", newValue.Name)
 		log.Debugf(msg)
@@ -154,8 +155,9 @@ func (chg change) patchVolume(override *composeOverride) (string, error) {
 			return "", err
 		}
 
-		newValue.Extensions[config.K8SExtensionKey] = minified
-		override.Volumes[chg.Index.(string)] = newValue
+		override.Volumes[chg.Index.(string)] = VolumeConfig{Name: newValue.Name, Extensions: map[string]interface{}{
+			config.K8SExtensionKey: minified,
+		}}
 
 		msg := fmt.Sprintf("added volume: %s", chg.Index.(string))
 		log.Debugf(msg)

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -256,9 +256,9 @@ var _ = Describe("Reconcile", func() {
 					envs, err := manifest.GetEnvironments([]string{"dev", "stage"})
 					Expect(err).ToNot(HaveOccurred())
 					for _, env := range envs {
-						Expect(env.GetServices()).To(HaveLen(2))
-						Expect(env.GetServices()[0].Name).To(Equal("db"))
-						Expect(env.GetServices()[1].Name).To(Equal("wordpress"))
+						Expect(env.GetServices()).To(HaveLen(2), "failed for env: %s", env.Name)
+						Expect(env.GetServices()[0].Name).To(Equal("db"), "failed for env: %s", env.Name)
+						Expect(env.GetServices()[1].Name).To(Equal("wordpress"), "failed for env: %s", env.Name)
 					}
 				})
 
@@ -269,7 +269,7 @@ var _ = Describe("Reconcile", func() {
 					envs, err := manifest.GetEnvironments([]string{"dev", "stage"})
 					Expect(err).ToNot(HaveOccurred())
 					for _, env := range envs {
-						Expect(env.GetServices()[1].Extensions).To(Equal(expected))
+						Expect(env.GetServices()[1].Extensions).To(Equal(expected), "failed for env: %s", env.Name)
 					}
 				})
 
@@ -277,7 +277,7 @@ var _ = Describe("Reconcile", func() {
 					envs, err := manifest.GetEnvironments([]string{"dev", "stage"})
 					Expect(err).ToNot(HaveOccurred())
 					for _, env := range envs {
-						Expect(env.GetServices()[1].Environment).To(HaveLen(0))
+						Expect(env.GetServices()[1].Environment).To(HaveLen(0), "failed for env: %s", env.Name)
 					}
 				})
 
@@ -357,8 +357,8 @@ var _ = Describe("Reconcile", func() {
 					v, _ := env.GetVolume("db_data")
 					volExt := v.Extensions[config.K8SExtensionKey].(map[string]interface{})
 
-					Expect(v.Extensions).To(HaveLen(1))
-					Expect(volExt["size"]).To(Equal("100Mi"))
+					Expect(v.Extensions).To(HaveLen(1), "failed for env: %s", env.Name)
+					Expect(volExt["size"]).To(Equal("100Mi"), "failed for env: %s", env.Name)
 				}
 
 			})

--- a/pkg/kev/services.go
+++ b/pkg/kev/services.go
@@ -89,12 +89,3 @@ func (sc ServiceConfig) detectSecretsInEnvVars(matchers []map[string]string) []s
 
 	return matches
 }
-
-// minusEnvVars returns a copy of the ServiceConfig with blank env vars
-func (sc ServiceConfig) minusEnvVars() ServiceConfig {
-	return ServiceConfig{
-		Name:        sc.Name,
-		Environment: map[string]*string{},
-		Extensions:  sc.Extensions,
-	}
-}

--- a/pkg/kev/testdata/reconcile-service-basic/docker-compose.kev.stage.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/docker-compose.kev.stage.yaml
@@ -1,0 +1,21 @@
+version: "3.7"
+services:
+  db:
+    x-k8s:
+      workload:
+        replicas: 1
+        livenessProbe: 
+          type: exec
+          exec:
+            command: ["echo", "Define healthcheck command for service db"]
+          initialDelay: 1m0s
+          period: 1m0s
+          failureThreashold: 3
+          timeout: 10s
+      service:
+        type: None
+volumes:
+  db_data:
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-service-basic/kev.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/kev.yaml
@@ -3,3 +3,4 @@ compose:
   - testdata/reconcile-service-basic/docker-compose.yaml
 environments:
   dev: testdata/reconcile-service-basic/docker-compose.kev.dev.yaml
+  stage: testdata/reconcile-service-basic/docker-compose.kev.stage.yaml

--- a/pkg/kev/testdata/reconcile-volume-add/docker-compose.kev.stage.yaml
+++ b/pkg/kev/testdata/reconcile-volume-add/docker-compose.kev.stage.yaml
@@ -1,0 +1,32 @@
+version: "3.7"
+services:
+  db:
+    x-k8s:
+      workload:
+        type: StatefulSet
+        replicas: 1
+        livenessProbe: 
+          type: exec
+          exec:
+            command: ["echo", "Define healthcheck command for service db"]
+          initialDelay: 1m0s
+          period: 1m0s
+          failureThreashold: 3
+          timeout: 10s
+      service:
+        type: None
+  wordpress:
+    x-k8s:
+      workload:
+        type: Deployment
+        replicas: 1
+        livenessProbe: 
+          type: exec
+          exec:
+            command: ["echo", "Define healthcheck command for service wordpress"]
+          initialDelay: 1m0s
+          period: 1m0s
+          failureThreashold: 3
+          timeout: 10s
+      service:
+        type: LoadBalancer

--- a/pkg/kev/testdata/reconcile-volume-add/kev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-add/kev.yaml
@@ -3,3 +3,4 @@ compose:
   - testdata/reconcile-volume-add/docker-compose.yaml
 environments:
   dev: testdata/reconcile-volume-add/docker-compose.kev.dev.yaml
+  stage: testdata/reconcile-volume-add/docker-compose.kev.stage.yaml


### PR DESCRIPTION
Resolves #573 

## Bug summary

During reconciliation, the base docker compose extensions map used to detect changes was mistakenly mutated.

This was not an issue if a single environment override was being reconciled.

But, it definitely was a problem if multiple environment overrides were reconciled at once as the first reconcile breaks the following reconcile.

## Bug fix

Ensure the underlying extensions map is not mutated and that a fresh one is created for reconciles "create" change.

Added tests to cover the regression.