### PR TITLE
Dev command environments handling fix

### DIFF
--- a/cmd/kev/cmd/dev.go
+++ b/cmd/kev/cmd/dev.go
@@ -139,7 +139,8 @@ func runDevCmd(cmd *cobra.Command, _ []string) error {
 	eventHandler := func(e kev.RunnerEvent, r kev.Runner) error { return nil }
 
 	var envs []string
-	if len(kevenv) > 0 {
+	if len(kevenv) > 0 && skaffold {
+		// when in --skaffold mode - only watch, render and deploy a specified environment
 		envs = append(envs, kevenv)
 	}
 

--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -154,7 +154,9 @@ func UpdateSkaffoldBuildArtifacts(path string, project *ComposeProject) error {
 // true - when list of artefacts was updated, false - otherwise
 func (s *SkaffoldManifest) UpdateBuildArtifacts(analysis *Analysis, project *ComposeProject) bool {
 	prevArts := s.Build.Artifacts
-
+	if prevArts == nil {
+		prevArts = []*latest.Artifact{}
+	}
 	sort.SliceStable(prevArts, func(i, j int) bool {
 		return prevArts[i].ImageName < prevArts[j].ImageName
 	})
@@ -162,6 +164,9 @@ func (s *SkaffoldManifest) UpdateBuildArtifacts(analysis *Analysis, project *Com
 	s.SetBuildArtifacts(analysis, project)
 
 	currArts := s.Build.Artifacts
+	if currArts == nil {
+		currArts = []*latest.Artifact{}
+	}
 	sort.SliceStable(currArts, func(i, j int) bool {
 		return currArts[i].ImageName < currArts[j].ImageName
 	})

--- a/pkg/kev/skaffold_test.go
+++ b/pkg/kev/skaffold_test.go
@@ -349,6 +349,23 @@ var _ = Describe("Skaffold", func() {
 				Expect(images).ToNot(ContainElement("quay.io/myorg/svc2"))
 			})
 		})
+
+		When("previous build artefacts were not defined (nil)", func() {
+			BeforeEach(func() {
+				skaffoldManifest.Build.Artifacts = nil
+			})
+
+			When("and current build artefacts were not detected (empty slice)", func() {
+				BeforeEach(func() {
+					analysis = nil
+					project.Services[0].Build = nil // reminder: images with no build context are excluded
+				})
+
+				It("returns false", func() {
+					Expect(changed).To(BeFalse())
+				})
+			})
+		})
 	})
 
 	Describe("InjectProfiles", func() {


### PR DESCRIPTION
Resolves: #575 

This PR fixes the way `dev` command handles project environments in such a way that:

1) in standard development loop (without Skaffold) it takes all tracked environments into account by default. It renders all envs K8s manifest upon change to any of the environment specific docker compose override files.

2) in development loop (with Skaffold activated) it only renders the K8s manifests for a specified environment (selected by `--kev-env` flag), or `dev` environment if none was specified. Specified environment's manifests are auto-deployed to a target K8s cluster.

It also fixes `manifest#UpdateBuildArtifacts` so that slices comparison works as expected. NOTE: `reflect.DeepEqual` treats nil and empty slice as non equal!