### PR TITLE
Add command config param

### DIFF
--- a/docs/reference/config-example.md
+++ b/docs/reference/config-example.md
@@ -19,7 +19,12 @@ services:                                                # compose services sect
           domain:                                        # Default: "" (no ingress). Possible options: "" | "default" | domain.com,otherdomain.com (comma separated domain names). When with "default" or domain name(s) - it'll generate an ingress object and expose service externally.
           tlsSecret:                                     # Default: "" (no tls). Kubernetes secret name where certs will be loaded from.
       workload:                                          # K8s workload configuration (only required if values are overridden)
-        annotations:                                     # Default: nil. A key/value map to attach metadata to a K8s Pod Spec in a deployable object, e.g. Deployment, StatefulSet, etc... 
+        command:                                         # Default: nil. When defined it'll override start command defined in the container.
+          - /bin/sh
+        commandArgs:                                     # Default: nil. When defined it'll override command arguments defined in the container.
+          - -c
+          - /do/something
+        annotations:                                     # Default: nil. A key/value map to attach metadata to a K8s Pod Spec in a deployable object, e.g. Deployment, StatefulSet, etc...
           key-one: value one
           key-two: value two
         autoscale:                                       # Configures an application for auto-scaling.

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -53,8 +53,49 @@ services:
 
 # → Workload
 
-This configuration group contains Kubernetes `workload` specific settings. Configuration parameters can be individually defined for each application stack component. 
+This configuration group contains Kubernetes `workload` specific settings. Configuration parameters can be individually defined for each application stack component.
 
+## workload.command
+
+Defines a command to run for given workload. If defined it'll take presedence over the default docker image command.
+
+### Default: nil (not specified - docker image command will be used)
+
+### Possible options: an array of string values.
+
+> workload.command:
+```yaml
+version: 3.7
+services:
+  my-service:
+    x-k8s:
+      workload:
+        command:
+          - /bin/sh
+          - -c
+          - /do/something && /run/my/program
+...
+```
+
+## workload.commandArgs
+
+Defines a command arguments for given workload. If defined it'll take presedence over the default docker image args.
+### Default: nil (not specified - docker image args will be used)
+
+### Possible options: an array of string values.
+
+> workload.commandArgs:
+```yaml
+version: 3.7
+services:
+  my-service:
+    x-k8s:
+      workload:
+        commandArgs:
+          - -c
+          - sleep 10 && /run/my/program
+...
+```
 ## workload.annotations
 
 A key/value map to attach metadata to a K8s Pod spec in a deployable object, e.g., Deployment, StatefulSet, etc... See official K8s [documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/).
@@ -74,7 +115,7 @@ services:
           key1: value 1
           key2: value 2
           key3: |
-            value 3 and value 4 
+            value 3 and value 4
 ...
 ```
 

--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -57,7 +57,7 @@ This configuration group contains Kubernetes `workload` specific settings. Confi
 
 ## workload.command
 
-Defines a command to run for given workload. If defined it'll take presedence over the default docker image command.
+Defines a command to run for given workload. If defined it'll take precedence over the default docker image command.
 
 ### Default: nil (not specified - docker image command will be used)
 
@@ -79,7 +79,7 @@ services:
 
 ## workload.commandArgs
 
-Defines a command arguments for given workload. If defined it'll take presedence over the default docker image args.
+Defines a command arguments for given workload. If defined it'll take precedence over the default docker image args.
 ### Default: nil (not specified - docker image args will be used)
 
 ### Possible options: an array of string values.

--- a/pkg/kev/config/svcext.go
+++ b/pkg/kev/config/svcext.go
@@ -427,6 +427,8 @@ type Workload struct {
 	Resource              Resource          `yaml:"resource,omitempty"`
 	Autoscale             Autoscale         `yaml:"autoscale,omitempty"`
 	PodSecurity           PodSecurity       `yaml:"podSecurity,omitempty"`
+	Command               []string          `yaml:"command,omitempty"`
+	CommandArgs           []string          `yaml:"commandArgs,omitempty"`
 }
 
 type Resource struct {

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -49,6 +49,50 @@ func (p *ProjectService) enabled() bool {
 	return !p.SvcK8sConfig.Disabled
 }
 
+// command returns the workload command
+// When defined via config extension takes presedence over Entrypoint defined by the compose service spec.
+// Compose project service spec Entrypoint is equivalent to a k8s command,
+// see: https://github.com/kubernetes/kompose/blob/0036f0c32b37d0a521421b76e58b580b7574c127/docs/conversion.md
+func (p *ProjectService) command() []string {
+	var out []string
+
+	if len(p.Entrypoint) > 0 {
+		out = []string(p.Entrypoint)
+	}
+
+	if len(p.SvcK8sConfig.Workload.Command) > 0 {
+		out = p.SvcK8sConfig.Workload.Command
+	}
+
+	if len(out) == 0 {
+		out = []string{}
+	}
+
+	return out
+}
+
+// commandArgs returns the workload command arguments.
+// When defined via config extension takes presedence over Command defined by the compose service spec.
+// Compose project service spec Command is equivalent to k8s args,
+// see: https://github.com/kubernetes/kompose/blob/0036f0c32b37d0a521421b76e58b580b7574c127/docs/conversion.md
+func (p *ProjectService) commandArgs() []string {
+	var out []string
+
+	if len(p.Command) > 0 {
+		out = []string(p.Command)
+	}
+
+	if len(p.SvcK8sConfig.Workload.CommandArgs) > 0 {
+		out = p.SvcK8sConfig.Workload.CommandArgs
+	}
+
+	if len(out) == 0 {
+		out = []string{}
+	}
+
+	return out
+}
+
 // podAnnotations returns the workload pod annotations
 func (p *ProjectService) podAnnotations() map[string]string {
 	out := p.SvcK8sConfig.Workload.Annotations

--- a/pkg/kev/converter/kubernetes/project_service.go
+++ b/pkg/kev/converter/kubernetes/project_service.go
@@ -50,7 +50,7 @@ func (p *ProjectService) enabled() bool {
 }
 
 // command returns the workload command
-// When defined via config extension takes presedence over Entrypoint defined by the compose service spec.
+// When defined via config extension takes precedence over Entrypoint defined by the compose service spec.
 // Compose project service spec Entrypoint is equivalent to a k8s command,
 // see: https://github.com/kubernetes/kompose/blob/0036f0c32b37d0a521421b76e58b580b7574c127/docs/conversion.md
 func (p *ProjectService) command() []string {
@@ -64,15 +64,11 @@ func (p *ProjectService) command() []string {
 		out = p.SvcK8sConfig.Workload.Command
 	}
 
-	if len(out) == 0 {
-		out = []string{}
-	}
-
 	return out
 }
 
 // commandArgs returns the workload command arguments.
-// When defined via config extension takes presedence over Command defined by the compose service spec.
+// When defined via config extension takes precedence over Command defined by the compose service spec.
 // Compose project service spec Command is equivalent to k8s args,
 // see: https://github.com/kubernetes/kompose/blob/0036f0c32b37d0a521421b76e58b580b7574c127/docs/conversion.md
 func (p *ProjectService) commandArgs() []string {
@@ -84,10 +80,6 @@ func (p *ProjectService) commandArgs() []string {
 
 	if len(p.SvcK8sConfig.Workload.CommandArgs) > 0 {
 		out = p.SvcK8sConfig.Workload.CommandArgs
-	}
-
-	if len(out) == 0 {
-		out = []string{}
 	}
 
 	return out

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -47,6 +47,8 @@ var _ = Describe("ProjectService", func() {
 		environment        composego.MappingWithEquals
 		healthcheck        composego.HealthCheckConfig
 		projectVolumes     composego.Volumes
+		command            composego.ShellCommand
+		args               composego.ShellCommand
 		svcK8sConfig       config.SvcK8sConfig
 	)
 
@@ -60,6 +62,8 @@ var _ = Describe("ProjectService", func() {
 		environment = composego.MappingWithEquals{}
 		healthcheck = composego.HealthCheckConfig{}
 		projectVolumes = composego.Volumes{}
+		command = composego.ShellCommand{}
+		args = composego.ShellCommand{}
 
 		svcK8sConfig = config.SvcK8sConfig{}
 	})
@@ -79,6 +83,8 @@ var _ = Describe("ProjectService", func() {
 			Environment: environment,
 			HealthCheck: &healthcheck,
 			Volumes:     volumes,
+			Entrypoint:  command,
+			Command:     args,
 			Extensions:  extensions,
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -117,6 +123,137 @@ var _ = Describe("ProjectService", func() {
 		When("component toggle extension is not specified", func() {
 			It("defaults to true", func() {
 				Expect(projectService.enabled()).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("command", func() {
+		customCommand := []string{
+			"/bin/bash",
+			"-c",
+			"sleep 1",
+		}
+
+		Context("when provided via extension", func() {
+
+			BeforeEach(func() {
+				svcK8sConfig.Workload.Command = customCommand
+			})
+
+			It("will use the extension value", func() {
+				Expect(projectService.command()).To(Equal(customCommand))
+			})
+		})
+
+		Context("when provided via both the extension and as part of the project service spec", func() {
+
+			BeforeEach(func() {
+				svcK8sConfig.Workload.Command = customCommand
+
+				command = []string{
+					"/default/command",
+				}
+			})
+
+			It("will use the extension value", func() {
+				Expect(projectService.command()).To(Equal(customCommand))
+			})
+		})
+
+		Context("when command not present in config extension but specified as part of the project service spec", func() {
+			BeforeEach(func() {
+				command = []string{
+					"/default/command",
+				}
+			})
+
+			It("will use a command as specified in the project service spec", func() {
+				Expect(projectService.command()).NotTo(BeEmpty())
+				Expect(projectService.command()).To(BeEquivalentTo(command))
+			})
+		})
+
+		Context("when there is no command supplied in neither config extension nor project service spec", func() {
+			It("will return an empty string slice", func() {
+				Expect(projectService.command()).To(Equal([]string{}))
+			})
+		})
+	})
+
+	Describe("commandArgs", func() {
+		customCommandArgs := []string{
+			"-c",
+			"sleep 1",
+		}
+
+		Context("when provided via config extension", func() {
+
+			BeforeEach(func() {
+				svcK8sConfig.Workload.CommandArgs = customCommandArgs
+			})
+
+			It("will use the extension value", func() {
+				Expect(projectService.commandArgs()).To(Equal(customCommandArgs))
+			})
+		})
+
+		Context("when provided via both the extension and as part of the project service spec", func() {
+
+			BeforeEach(func() {
+				svcK8sConfig.Workload.CommandArgs = customCommandArgs
+
+				args = []string{
+					"/default/command",
+				}
+			})
+
+			It("will use the extension value", func() {
+				Expect(projectService.commandArgs()).To(Equal(customCommandArgs))
+			})
+		})
+
+		Context("when command args not present in config extension but specified as part of the project service spec", func() {
+			BeforeEach(func() {
+				args = []string{
+					"/default/command",
+				}
+			})
+
+			It("will use a command args as specified in the project service spec", func() {
+				Expect(projectService.commandArgs()).NotTo(BeEmpty())
+				Expect(projectService.commandArgs()).To(BeEquivalentTo(args))
+			})
+		})
+
+		Context("when there is no command args specified via config extension", func() {
+			It("will return an empty string slice", func() {
+				Expect(projectService.commandArgs()).To(Equal([]string{}))
+			})
+		})
+	})
+
+	Describe("podAnnotations", func() {
+		annotations := map[string]string{
+			"key1": "val1",
+			"key2": "val2",
+		}
+
+		Context("when provided via config extension", func() {
+
+			BeforeEach(func() {
+				svcK8sConfig.Workload.Annotations = annotations
+			})
+
+			It("will use the extension value", func() {
+				Expect(projectService.podAnnotations()).To(HaveKeyWithValue("key1", "val1"))
+				Expect(projectService.podAnnotations()).To(HaveKeyWithValue("key2", "val2"))
+				Expect(projectService.podAnnotations()).To(HaveLen(2))
+			})
+		})
+
+		Context("when there is no annotations specified via config extension", func() {
+			It("will return an empty string -> string map", func() {
+				Expect(projectService.podAnnotations()).To(Equal(map[string]string{}))
 			})
 		})
 	})

--- a/pkg/kev/converter/kubernetes/project_service_test.go
+++ b/pkg/kev/converter/kubernetes/project_service_test.go
@@ -174,8 +174,8 @@ var _ = Describe("ProjectService", func() {
 		})
 
 		Context("when there is no command supplied in neither config extension nor project service spec", func() {
-			It("will return an empty string slice", func() {
-				Expect(projectService.command()).To(Equal([]string{}))
+			It("will return nil", func() {
+				Expect(projectService.command()).To(BeNil())
 			})
 		})
 	})
@@ -226,8 +226,8 @@ var _ = Describe("ProjectService", func() {
 		})
 
 		Context("when there is no command args specified via config extension", func() {
-			It("will return an empty string slice", func() {
-				Expect(projectService.commandArgs()).To(Equal([]string{}))
+			It("will return nil", func() {
+				Expect(projectService.commandArgs()).To(BeNil())
 			})
 		})
 	})
@@ -253,7 +253,7 @@ var _ = Describe("ProjectService", func() {
 
 		Context("when there is no annotations specified via config extension", func() {
 			It("will return an empty string -> string map", func() {
-				Expect(projectService.podAnnotations()).To(Equal(map[string]string{}))
+				Expect(projectService.podAnnotations()).To(HaveLen(0))
 			})
 		})
 	})

--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -244,6 +244,12 @@ func (k *Kubernetes) initPodSpec(projectService ProjectService) v1.PodSpec {
 	// @step get service account for the pod
 	serviceAccount := projectService.serviceAccountName()
 
+	// @step get command for the container
+	command := projectService.command()
+
+	// @step get command arguments for the container
+	commandArgs := projectService.commandArgs()
+
 	pod := v1.PodSpec{
 		Containers: []v1.Container{
 			{
@@ -251,6 +257,12 @@ func (k *Kubernetes) initPodSpec(projectService ProjectService) v1.PodSpec {
 				Image: image,
 			},
 		},
+	}
+	if len(command) > 0 {
+		pod.Containers[0].Command = command
+	}
+	if len(commandArgs) > 0 {
+		pod.Containers[0].Args = commandArgs
 	}
 	if pullSecret != "" {
 		pod.ImagePullSecrets = []v1.LocalObjectReference{
@@ -1693,8 +1705,8 @@ func (k *Kubernetes) updateKubernetesObjects(projectService ProjectService, obje
 			template.Spec.Containers[0].Name = rfc1123dns(projectService.ContainerName)
 		}
 		template.Spec.Containers[0].Env = envs
-		template.Spec.Containers[0].Command = projectService.Entrypoint
-		template.Spec.Containers[0].Args = projectService.Command
+		template.Spec.Containers[0].Command = projectService.command()
+		template.Spec.Containers[0].Args = projectService.commandArgs()
 		template.Spec.Containers[0].WorkingDir = projectService.WorkingDir
 		template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts, volumesMounts...)
 		template.Spec.Containers[0].Stdin = projectService.StdinOpen


### PR DESCRIPTION
Resolves #582 

This PR adds the following:
* adds `workload.command` & `workload.commandArgs` config options
* updates config reference doc

Now it's possible to override a command / args in compose config extension.