### PR TITLE
Generate ServiceAccount manifest for eligible objects if service account name specified

### DIFF
--- a/pkg/kev/converter/kubernetes/transform.go
+++ b/pkg/kev/converter/kubernetes/transform.go
@@ -789,9 +789,9 @@ func (k *Kubernetes) initHpa(projectService ProjectService, target runtime.Objec
 	}
 }
 
-// initSa initialises Service Account for a project service
+// initServiceAccount initialises Service Account for a project service
 // It only creates the ServiceAccount spec for accounts with name other than `default`
-func (k *Kubernetes) initSa(projectService ProjectService) *v1.ServiceAccount {
+func (k *Kubernetes) initServiceAccount(projectService ProjectService) *v1.ServiceAccount {
 	automountSAToken := false
 	saname := projectService.serviceAccountName()
 
@@ -1495,7 +1495,7 @@ func (k *Kubernetes) createKubernetesObjects(projectService ProjectService) []ru
 	}
 
 	// @step create a Service Account if speficied
-	if sa := k.initSa(projectService); sa != nil {
+	if sa := k.initServiceAccount(projectService); sa != nil {
 		objects = append(objects, sa)
 	}
 

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1218,6 +1218,58 @@ var _ = Describe("Transform", func() {
 
 	})
 
+	Describe("initSa", func() {
+		When("service account name is specified as empty string in the workload configuration", func() {
+			BeforeEach(func() {
+				projectService.SvcK8sConfig.Workload.ServiceAccountName = ""
+			})
+
+			It("doesn't initialize ServiceAccount for that project service", func() {
+				sa := k.initSa(projectService)
+				Expect(sa).To(BeNil())
+			})
+		})
+
+		When("service account name is defined as `default`", func() {
+			BeforeEach(func() {
+				projectService.SvcK8sConfig.Workload.ServiceAccountName = "default"
+			})
+
+			It("doesn't initialize ServiceAccount for that project service", func() {
+				sa := k.initSa(projectService)
+				Expect(sa).To(BeNil())
+			})
+		})
+
+		When("service account name is specified with name different than `default`", func() {
+			BeforeEach(func() {
+				projectService.SvcK8sConfig.Workload.ServiceAccountName = "mysvcacc"
+			})
+
+			It("initializes ServiceAccount for the project service", func() {
+				sa := k.initSa(projectService)
+				Expect(sa).ToNot(BeNil())
+
+				automountSAToken := false
+
+				expected := &v1.ServiceAccount{
+					TypeMeta: meta.TypeMeta{
+						Kind:       "ServiceAccount",
+						APIVersion: "v1",
+					},
+					ObjectMeta: meta.ObjectMeta{
+						Name:        "mysvcacc",
+						Labels:      configLabels(projectService.Name),
+						Annotations: configAnnotations(projectService.Labels),
+					},
+					AutomountServiceAccountToken: &automountSAToken,
+				}
+
+				Expect(sa).To(Equal(expected))
+			})
+		})
+	})
+
 	Describe("createSecrets", func() {
 		secretName := "my-secret"
 		var secretConfig composego.SecretConfig

--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1225,7 +1225,7 @@ var _ = Describe("Transform", func() {
 			})
 
 			It("doesn't initialize ServiceAccount for that project service", func() {
-				sa := k.initSa(projectService)
+				sa := k.initServiceAccount(projectService)
 				Expect(sa).To(BeNil())
 			})
 		})
@@ -1236,7 +1236,7 @@ var _ = Describe("Transform", func() {
 			})
 
 			It("doesn't initialize ServiceAccount for that project service", func() {
-				sa := k.initSa(projectService)
+				sa := k.initServiceAccount(projectService)
 				Expect(sa).To(BeNil())
 			})
 		})
@@ -1247,7 +1247,7 @@ var _ = Describe("Transform", func() {
 			})
 
 			It("initializes ServiceAccount for the project service", func() {
-				sa := k.initSa(projectService)
+				sa := k.initServiceAccount(projectService)
 				Expect(sa).ToNot(BeNil())
 
 				automountSAToken := false


### PR DESCRIPTION
Resolves: #583 

When workload's k8s configuration specifies a service account name other than `default` it'll result in ServiceAccount manifest being generated when `render` command is executed. 

It's a NOOP for `default` service account name.