### PR TITLE
Fixes environment variable symbolic value handling

### DIFF
--- a/pkg/kev/converter/kubernetes/transform_test.go
+++ b/pkg/kev/converter/kubernetes/transform_test.go
@@ -1754,7 +1754,7 @@ var _ = Describe("Transform", func() {
 
 		Context("for environment variables values that start with a special case keywords", func() {
 
-			When("env var value starts with `secret` but doesn't have expected format", func() {
+			When("env var value starts with a special keyword but doesn't have an expected format", func() {
 				secret := "secret.foo"
 				config := "config.bar"
 				pod := "pod.baz"


### PR DESCRIPTION
Addresses #607 

This Bugfix PR changes the way environment variable symbolic values are handled, specifically:
* variables values that contain special case keyword such as `secret`, `config`, `pod`, `container` is treated as literal string unless it matches specific format that would indicate Kubernetes object should be referenced instead.  
* Adds validation to the expected format for symbolic values
* Returns explicit errors on malformed / unsupported symbolic values