### PR TITLE
Allow updates to images in override files

### DIFF
--- a/pkg/kev/changeset.go
+++ b/pkg/kev/changeset.go
@@ -140,6 +140,21 @@ func (chg change) patchService(override *composeOverride) (string, error) {
 
 			svc.Extensions[config.K8SExtensionKey] = newValue
 			log.Debugf("service [%s] extensions updated to %+v", svcName, newValue)
+		case "services":
+			// Currently, the only update that can occur to a service is
+			// its image name. This will likely change in future.
+			svc := override.Services[chg.Index.(int)]
+			svcName := svc.Name
+
+			newValue, ok := chg.Value.(string)
+			if !ok {
+				log.Debugf("unable to update service image [%s], invalid value %+v", svcName, newValue)
+				return "", nil
+			}
+			svc.Image = newValue
+			msg := fmt.Sprintf("updated image to: %s", newValue)
+			log.Debugf(msg)
+			return msg, nil
 		}
 	}
 	return "", nil

--- a/pkg/kev/init_test.go
+++ b/pkg/kev/init_test.go
@@ -275,5 +275,39 @@ var _ = Describe("InitRunner", func() {
 				})
 			})
 		})
+		When("image name not defined in the sources", func() {
+			Context("Image name is not defined", func() {
+				BeforeEach(func() {
+					workingDir = "./testdata/init-image/no-image"
+				})
+				It("should be empty in the override", func() {
+					var buffer bytes.Buffer
+					_, err := env.WriteTo(&buffer)
+					Expect(err).ToNot(HaveOccurred())
+
+					expected, err := ioutil.ReadFile("./testdata/init-image/no-image/output.yaml")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(buffer.String()).To(MatchYAML(expected))
+				})
+			})
+		})
+		When("image name defined in the sources", func() {
+			BeforeEach(func() {
+				workingDir = "./testdata/init-image/image"
+			})
+			Context("Image name is provided", func() {
+				It("should be written to the override", func() {
+					var buffer bytes.Buffer
+					_, err := env.WriteTo(&buffer)
+					Expect(err).ToNot(HaveOccurred())
+
+					expected, err := ioutil.ReadFile("./testdata/init-image/image/output.yaml")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(buffer.String()).To(MatchYAML(expected))
+				})
+			})
+		})
 	})
 })

--- a/pkg/kev/services.go
+++ b/pkg/kev/services.go
@@ -25,7 +25,12 @@ import (
 )
 
 func newServiceConfig(s composego.ServiceConfig) (ServiceConfig, error) {
-	config := ServiceConfig{Name: s.Name, Environment: s.Environment, Extensions: s.Extensions}
+	config := ServiceConfig{
+		Name:        s.Name,
+		Image:       s.Image,
+		Environment: s.Environment,
+		Extensions:  s.Extensions,
+	}
 	return config, nil
 }
 

--- a/pkg/kev/sources.go
+++ b/pkg/kev/sources.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/appvia/kev/pkg/kev/config"
 	"github.com/appvia/kev/pkg/kev/log"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -47,6 +48,7 @@ func (s *Sources) CalculateBaseOverride(opts ...BaseOverrideOpts) error {
 	for _, svc := range ready.Services {
 		target := ServiceConfig{
 			Name:       svc.Name,
+			Image:      svc.Image,
 			Extensions: svc.Extensions,
 		}
 
@@ -123,6 +125,7 @@ func withEnvVars(s *Sources, origin *ComposeProject) error {
 
 		services = append(services, ServiceConfig{
 			Name:        svc.Name,
+			Image:       originSvc.Image,
 			Environment: originSvc.Environment,
 			Extensions:  svc.Extensions,
 		})

--- a/pkg/kev/testdata/init-default/compose-yaml-src-ext/output.yaml
+++ b/pkg/kev/testdata/init-default/compose-yaml-src-ext/output.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 10

--- a/pkg/kev/testdata/init-default/compose-yaml/output.yaml
+++ b/pkg/kev/testdata/init-default/compose-yaml/output.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/init-default/docker-compose-override/docker-compose.override.yaml
+++ b/pkg/kev/testdata/init-default/docker-compose-override/docker-compose.override.yaml
@@ -1,6 +1,7 @@
 version: '3.9'
 services:
   db:
+    image: mysql:8.0.19
     command: '--default-authentication-plugin=mysql_native_password'
     restart: always
     volumes:

--- a/pkg/kev/testdata/init-image/image/compose.yaml
+++ b/pkg/kev/testdata/init-image/image/compose.yaml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8.0.19
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+volumes:
+  db_data:
+

--- a/pkg/kev/testdata/init-image/image/output.yaml
+++ b/pkg/kev/testdata/init-image/image/output.yaml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:8.0.19
+    x-k8s:
+      workload:
+        replicas: 1
+volumes:
+  db_data:
+    x-k8s:
+      size: 100Mi

--- a/pkg/kev/testdata/init-image/no-image/compose.yaml
+++ b/pkg/kev/testdata/init-image/no-image/compose.yaml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  db:
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+volumes:
+  db_data:
+

--- a/pkg/kev/testdata/init-image/no-image/output.yaml
+++ b/pkg/kev/testdata/init-image/no-image/output.yaml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  db:
+    x-k8s:
+      workload:
+        replicas: 1
+volumes:
+  db_data:
+    x-k8s:
+      size: 100Mi

--- a/pkg/kev/testdata/reconcile-env-var-override/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-override/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-env-var-removal/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-removal/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1
@@ -15,6 +16,7 @@ services:
       service:
         type: None
   wordpress:
+    image: wordpress:latest
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         type: StatefulSet

--- a/pkg/kev/testdata/reconcile-healthcheck-http/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-healthcheck-http/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1
@@ -16,6 +17,7 @@ services:
       service:
         type: None
   wordpress:
+    image: wordpress:latest
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-healthcheck-tcp/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-healthcheck-tcp/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-override-keep/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-override-keep/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         type: StatefulSet

--- a/pkg/kev/testdata/reconcile-override-rollback/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-override-rollback/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-basic/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-basic/docker-compose.env.stage.yaml
+++ b/pkg/kev/testdata/reconcile-service-basic/docker-compose.env.stage.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-deploy/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-deploy/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-edit/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-edit/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1
@@ -15,6 +16,7 @@ services:
       service:
         type: ClusterIP
   wordpress:
+    image: wordpress:latest
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-healthcheck/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-healthcheck/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-service-removal/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-service-removal/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-version/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-version/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-volume-add/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-add/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         type: StatefulSet
@@ -16,6 +17,7 @@ services:
       service:
         type: None
   wordpress:
+    image: wordpress:latest
     x-k8s:
       workload:
         type: Deployment

--- a/pkg/kev/testdata/reconcile-volume-add/docker-compose.env.stage.yaml
+++ b/pkg/kev/testdata/reconcile-volume-add/docker-compose.env.stage.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         type: StatefulSet
@@ -17,6 +18,7 @@ services:
         type: None
   wordpress:
     x-k8s:
+      image: wordpress:latest
       workload:
         type: Deployment
         replicas: 1

--- a/pkg/kev/testdata/reconcile-volume-edit/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-edit/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/reconcile-volume-removal/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-volume-removal/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1
@@ -15,6 +16,7 @@ services:
       service:
         type: None
   wordpress:
+    image: wordpress:latest
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/testdata/validation/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/validation/docker-compose.env.dev.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   db:
+    image: mysql:8.0.19
     x-k8s:
       workload:
         replicas: 1

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -137,7 +137,7 @@ type ComposeProject struct {
 // ServiceConfig is a shallow version of a compose-go ServiceConfig
 type ServiceConfig struct {
 	Name        string                      `yaml:"-" json:"-" diff:"name"`
-	Image       string                      `yaml:"image" json:"-" diff:"image"`
+	Image       string                      `yaml:"image,omitempty" json:"-" diff:"image"`
 	Environment composego.MappingWithEquals `yaml:",omitempty" json:"environment,omitempty" diff:"environment"`
 	Extensions  map[string]interface{}      `yaml:",inline" json:"-"`
 }

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -137,6 +137,7 @@ type ComposeProject struct {
 // ServiceConfig is a shallow version of a compose-go ServiceConfig
 type ServiceConfig struct {
 	Name        string                      `yaml:"-" json:"-" diff:"name"`
+	Image       string                      `yaml:"image" json:"-" diff:"image"`
 	Environment composego.MappingWithEquals `yaml:",omitempty" json:"environment,omitempty" diff:"environment"`
 	Extensions  map[string]interface{}      `yaml:",inline" json:"-"`
 }


### PR DESCRIPTION
Allows users to change the image names in override files, and persist these in the generated k8s manifests. This allows users to specify different image files for different environments (which otherwise cannot be done when deriving images from a single `docker-compose.yaml` alone.)

This change adds a new `Image` field to the `ServiceConfig` struct, and adds new Service update handling to the overrides/changesets. Test fixture files have been updated to reflect the fact they now always contain images for defined services.