### PR TITLE
Bump k8s ingress api to v1

### DIFF
--- a/docs/reference/config-params.md
+++ b/docs/reference/config-params.md
@@ -1114,7 +1114,9 @@ Defines how to expose the service externally. By default, all component services
 #### Possible options:
 
 - "default" - ingress will be created with Kubernetes cluster defaults.
-- "domain.com,otherdomain.com..." - comma separated list of domains for the ingress.
+- "domain.com" - a single domain name for the ingress.
+- "domain.com/foo" - a single domain name with a path.
+- "domain.com,otherdomain.com/bar,..." - comma separated list of domains (with or without path) for the ingress.
 
 #### Default: `""` - No ingress will be created!
 

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -962,13 +962,16 @@ func hasDefaultIngressBackendKeyword(v []string) bool {
 
 // createIngressRule creates an ingress rule using a set of parameters.
 func createIngressRule(host, path, serviceName string, port int32) networkingv1.IngressRule {
+	pathType := networkingv1.PathTypeImplementationSpecific
+
 	return networkingv1.IngressRule{
 		Host: host,
 		IngressRuleValue: networkingv1.IngressRuleValue{
 			HTTP: &networkingv1.HTTPIngressRuleValue{
 				Paths: []networkingv1.HTTPIngressPath{
 					{
-						Path: path,
+						Path:     path,
+						PathType: &pathType,
 						Backend: networkingv1.IngressBackend{
 							Service: &networkingv1.IngressServiceBackend{
 								Name: serviceName,

--- a/pkg/kev/converter/kubernetes/utils.go
+++ b/pkg/kev/converter/kubernetes/utils.go
@@ -40,12 +40,11 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Selector used as labels and selector
@@ -962,18 +961,20 @@ func hasDefaultIngressBackendKeyword(v []string) bool {
 }
 
 // createIngressRule creates an ingress rule using a set of parameters.
-func createIngressRule(host, path, serviceName string, port int32) networkingv1beta1.IngressRule {
-	return networkingv1beta1.IngressRule{
+func createIngressRule(host, path, serviceName string, port int32) networkingv1.IngressRule {
+	return networkingv1.IngressRule{
 		Host: host,
-		IngressRuleValue: networkingv1beta1.IngressRuleValue{
-			HTTP: &networkingv1beta1.HTTPIngressRuleValue{
-				Paths: []networkingv1beta1.HTTPIngressPath{
+		IngressRuleValue: networkingv1.IngressRuleValue{
+			HTTP: &networkingv1.HTTPIngressRuleValue{
+				Paths: []networkingv1.HTTPIngressPath{
 					{
 						Path: path,
-						Backend: networkingv1beta1.IngressBackend{
-							ServiceName: serviceName,
-							ServicePort: intstr.IntOrString{
-								IntVal: port,
+						Backend: networkingv1.IngressBackend{
+							Service: &networkingv1.IngressServiceBackend{
+								Name: serviceName,
+								Port: networkingv1.ServiceBackendPort{
+									Number: port,
+								},
 							},
 						},
 					},

--- a/pkg/kev/converter/kubernetes/utils_test.go
+++ b/pkg/kev/converter/kubernetes/utils_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	v1apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -70,10 +70,10 @@ var _ = Describe("Utils", func() {
 			})
 
 			Context("when schema group version is empty", func() {
-				o := &v1beta1.Deployment{
+				o := &v1apps.Deployment{
 					TypeMeta: meta.TypeMeta{
 						Kind:       "Deployment",
-						APIVersion: "extensions/v1beta1",
+						APIVersion: "apps/v1",
 					},
 				}
 				gv := schema.GroupVersion{}
@@ -84,8 +84,8 @@ var _ = Describe("Utils", func() {
 
 					info := versioned.DeepCopyObject().GetObjectKind().GroupVersionKind()
 					Expect(info.Kind).To(Equal("Deployment"))
-					Expect(info.Version).To(Equal("v1beta1"))
-					Expect(info.Group).To(Equal("extensions"))
+					Expect(info.Version).To(Equal("v1"))
+					Expect(info.Group).To(Equal("apps"))
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})


### PR DESCRIPTION
Resolves #616 

This PR updates generated ingress object to `v1` from previous `v1beta1`. 