### PR TITLE
Allow image name overrides in environment override files

### DIFF
--- a/pkg/kev/override.go
+++ b/pkg/kev/override.go
@@ -314,6 +314,12 @@ func (o *composeOverride) mergeServicesInto(p *ComposeProject) error {
 
 		envVarsFromNilToBlankInService(base)
 
+		// Copy over image name if one has bee defined in the override. In
+		// future this may expand to invlude other fields.
+		if override.Image != "" && override.Image != base.Image {
+			base.Image = override.Image
+		}
+
 		if err := mergo.Merge(&base.Extensions, &override.Extensions, mergo.WithOverride); err != nil {
 			return errors.Wrapf(err, "cannot merge extensions for service %s", override.Name)
 		}

--- a/pkg/kev/override.go
+++ b/pkg/kev/override.go
@@ -18,6 +18,7 @@ package kev
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/appvia/kev/pkg/kev/log"
 	kmd "github.com/appvia/komando"
@@ -316,7 +317,8 @@ func (o *composeOverride) mergeServicesInto(p *ComposeProject) error {
 
 		// Copy over image name if one has bee defined in the override. In
 		// future this may expand to invlude other fields.
-		if override.Image != "" && override.Image != base.Image {
+		trimmed := strings.TrimSpace(override.Image)
+		if trimmed != "" && trimmed != base.Image {
 			base.Image = override.Image
 		}
 

--- a/pkg/kev/services.go
+++ b/pkg/kev/services.go
@@ -25,7 +25,12 @@ import (
 )
 
 func newServiceConfig(s composego.ServiceConfig) (ServiceConfig, error) {
-	config := ServiceConfig{Name: s.Name, Environment: s.Environment, Extensions: s.Extensions}
+	config := ServiceConfig{
+		Name:        s.Name,
+		Image:       s.Image,
+		Environment: s.Environment,
+		Extensions:  s.Extensions,
+	}
 	return config, nil
 }
 

--- a/pkg/kev/testdata/reconcile-image-name-override/appmeta.yaml
+++ b/pkg/kev/testdata/reconcile-image-name-override/appmeta.yaml
@@ -1,0 +1,6 @@
+id: 10b5c35d-8b9a-42af-a16e-ed758a06c231
+compose:
+  - testdata/reconcile-image-name-override/docker-compose.yaml
+environments:
+  dev: testdata/reconcile-image-name-override/docker-compose.env.dev.yaml
+  stage: testdata/reconcile-image-name-override/docker-compose.env.stage.yaml

--- a/pkg/kev/testdata/reconcile-image-name-override/docker-compose.env.dev.yaml
+++ b/pkg/kev/testdata/reconcile-image-name-override/docker-compose.env.dev.yaml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:latest
+    x-k8s:
+      workload:
+        replicas: 1
+        livenessProbe: 
+          type: exec
+          exec:
+            command: ["echo", "Define healthcheck command for service db"]
+          initialDelay: 1m0s
+          period: 1m0s
+          failureThreashold: 3
+          timeout: 10s
+      service:
+        type: None
+    environment:
+      - TO_OVERRIDE=value
+volumes:
+  db_data:
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-image-name-override/docker-compose.env.stage.yaml
+++ b/pkg/kev/testdata/reconcile-image-name-override/docker-compose.env.stage.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  db:
+    x-k8s:
+      workload:
+        replicas: 1
+        livenessProbe: 
+          type: exec
+          exec:
+            command: ["echo", "Define healthcheck command for service db"]
+          initialDelay: 1m0s
+          period: 1m0s
+          failureThreashold: 3
+          timeout: 10s
+      service:
+        type: None
+    environment:
+      - TO_OVERRIDE=value
+volumes:
+  db_data:
+    x-k8s:
+      size: 100Mi
+      storageClass: standard

--- a/pkg/kev/testdata/reconcile-image-name-override/docker-compose.yaml
+++ b/pkg/kev/testdata/reconcile-image-name-override/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8.0.19
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+      - TO_OVERRIDE=value
+volumes:
+  db_data:
+

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -137,6 +137,7 @@ type ComposeProject struct {
 // ServiceConfig is a shallow version of a compose-go ServiceConfig
 type ServiceConfig struct {
 	Name        string                      `yaml:"-" json:"-" diff:"name"`
+	Image       string                      `yaml:"image,omitempty" json:"-" diff:"image"`
 	Environment composego.MappingWithEquals `yaml:",omitempty" json:"environment,omitempty" diff:"environment"`
 	Extensions  map[string]interface{}      `yaml:",inline" json:"-"`
 }


### PR DESCRIPTION
Allow users to override the images in the environment override files, and persist these in the generated k8s manifests. This allows users to specify different images for different environments.

This change adds a new `Image` field to the `ServiceConfig` struct, and modifies the post-reconciliation merging to copy over override image names, if present. Unit tests are modeled on those checking env var overrides, and ensure that the reconciliation processing does not remove any specified image names in the overrides.

This PR replaces #610.