### PR TITLE
Add ability to add custom manifests to the rendered output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     executor:
       name: go/default
-      tag: '1.14'
+      tag: '1.19'
     steps:
      - checkout
      - go/load-cache

--- a/cmd/kev/cmd/render.go
+++ b/cmd/kev/cmd/render.go
@@ -70,6 +70,13 @@ func init() {
 		"Target environment for which deployment files should be rendered",
 	)
 
+	flags.StringSliceP(
+		"additional-manifests",
+		"a",
+		[]string{},
+		"Additional Kubernetes manifests to be included in the output",
+	)
+
 	rootCmd.AddCommand(renderCmd)
 }
 
@@ -79,6 +86,7 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 	dir, _ := cmd.Flags().GetString("dir")
 	envs, _ := cmd.Flags().GetStringSlice("environment")
 	verbose, _ := cmd.Root().Flags().GetBool("verbose")
+	additionalManifests, _ := cmd.Flags().GetStringSlice("additional-manifests")
 
 	// The working directory is always the current directory.
 	// This ensures created manifest yaml entries are portable between users and require no path fixing.
@@ -88,6 +96,7 @@ func runRenderCmd(cmd *cobra.Command, _ []string) error {
 		kev.WithAppName(rootCmd.Use),
 		kev.WithManifestFormat(format),
 		kev.WithManifestsAsSingleFile(singleFile),
+		kev.WithAdditionalManifests(additionalManifests),
 		kev.WithOutputDir(dir),
 		kev.WithEnvs(envs),
 		kev.WithLogVerbose(verbose),

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
+	k8s.io/client-go v0.19.7
 )
 
 require (
@@ -181,7 +182,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/client-go v0.19.7 // indirect
 	k8s.io/klog/v2 v2.5.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f // indirect
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73 // indirect

--- a/pkg/kev/converter/converter.go
+++ b/pkg/kev/converter/converter.go
@@ -30,6 +30,7 @@ type Converter interface {
 		dir, workDir string,
 		projects map[string]*composego.Project,
 		files map[string][]string,
+		additionalManifests []string,
 		rendered map[string][]byte,
 		excluded map[string][]string) (map[string]string, error)
 }

--- a/pkg/kev/converter/dummy/converter.go
+++ b/pkg/kev/converter/dummy/converter.go
@@ -37,6 +37,7 @@ func (c *Dummy) Render(singleFile bool,
 	dir, workDir string,
 	projects map[string]*composego.Project,
 	files map[string][]string,
+	additionalManifests []string,
 	rendered map[string][]byte,
 	excluded map[string][]string) (map[string]string, error) {
 

--- a/pkg/kev/converter/kubernetes/converter.go
+++ b/pkg/kev/converter/kubernetes/converter.go
@@ -122,7 +122,7 @@ func (c *K8s) Render(singleFile bool,
 		}
 
 		// @step Produce objects
-		err = PrintList(objects, convertOpts, rendered)
+		err = PrintList(objects, convertOpts, additionalFiles, rendered)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not render %s manifests to disk, details:\n", Name)
 		}

--- a/pkg/kev/converter/kubernetes/converter.go
+++ b/pkg/kev/converter/kubernetes/converter.go
@@ -56,11 +56,13 @@ func (c *K8s) Render(singleFile bool,
 	dir, workDir string,
 	projects map[string]*composego.Project,
 	files map[string][]string,
+	additionalFiles []string,
 	rendered map[string][]byte,
 	excluded map[string][]string) (map[string]string, error) {
 
 	renderOutputPaths := map[string]string{}
 	envs := getSortedEnvs(projects)
+
 	for _, env := range envs {
 		project := projects[env]
 

--- a/pkg/kev/kev.go
+++ b/pkg/kev/kev.go
@@ -64,7 +64,7 @@ func RenderProjectWithOptions(workingDir string, opts ...Options) error {
 		return err
 	}
 
-	return printRenderProjectWithOptionsSuccess(runner, results, envs, runner.config.ManifestFormat)
+	return printRenderProjectWithOptionsSuccess(runner, results, envs)
 }
 
 // DevWithOptions runs a continuous development cycle detecting project updates and

--- a/pkg/kev/manifest.go
+++ b/pkg/kev/manifest.go
@@ -282,7 +282,7 @@ func (m *Manifest) MergeEnvIntoSources(e *Environment) (*ComposeProject, error) 
 }
 
 // RenderWithConvertor renders K8s manifests with specific converter
-func (m *Manifest) RenderWithConvertor(c converter.Converter, outputDir string, singleFile bool, envs []string, excluded map[string][]string) (map[string]string, error) {
+func (m *Manifest) RenderWithConvertor(c converter.Converter, runc *runConfig) (map[string]string, error) {
 	errSg := m.UI.StepGroup()
 	defer errSg.Done()
 
@@ -291,7 +291,7 @@ func (m *Manifest) RenderWithConvertor(c converter.Converter, outputDir string, 
 		return nil, err
 	}
 
-	filteredEnvs, err := m.GetEnvironments(envs)
+	filteredEnvs, err := m.GetEnvironments(runc.Envs)
 	if err != nil {
 		renderStepError(m.UI, errSg.Add(""), renderStepRenderGeneral, err)
 		return nil, err
@@ -313,7 +313,8 @@ func (m *Manifest) RenderWithConvertor(c converter.Converter, outputDir string, 
 		files[env.Name] = append(sourcesFiles, env.File)
 	}
 
-	outputPaths, err := c.Render(singleFile, outputDir, m.getWorkingDir(), projects, files, rendered, excluded)
+	outputPaths, err := c.Render(runc.ManifestsAsSingleFile, runc.OutputDir, m.getWorkingDir(),
+		projects, files, runc.AdditionalManifests, rendered, runc.ExcludeServicesByEnv)
 	if err != nil {
 		renderStepError(m.UI, errSg.Add(""), renderStepRenderGeneral, err)
 		return nil, err

--- a/pkg/kev/project.go
+++ b/pkg/kev/project.go
@@ -241,6 +241,14 @@ func WithManifestsAsSingleFile(c bool) Options {
 	}
 }
 
+// WithAdditionalManifests configures a project's run config with additional manifests that should be added
+// in the output directory.
+func WithAdditionalManifests(c []string) Options {
+	return func(project *Project, cfg *runConfig) {
+		cfg.AdditionalManifests = c
+	}
+}
+
 // WithOutputDir configures a project's run config with a location to render a project's K8s manifests.
 func WithOutputDir(c string) Options {
 	return func(project *Project, cfg *runConfig) {

--- a/pkg/kev/render.go
+++ b/pkg/kev/render.go
@@ -212,13 +212,7 @@ func (r *RenderRunner) RenderFromComposeToK8sManifests() (map[string]string, err
 	manifestFormat := r.config.ManifestFormat
 	r.UI.Header(fmt.Sprintf("Rendering manifests, format: %s...", manifestFormat))
 
-	results, err := r.manifest.RenderWithConvertor(
-		converter.Factory(manifestFormat, r.UI),
-		r.config.OutputDir,
-		r.config.ManifestsAsSingleFile,
-		r.config.Envs,
-		r.config.ExcludeServicesByEnv,
-	)
+	results, err := r.manifest.RenderWithConvertor(converter.Factory(manifestFormat, r.UI), r.config)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +234,7 @@ func printRenderProjectWithOptionsError(appName string, ui kmd.UI) {
 	)
 }
 
-func printRenderProjectWithOptionsSuccess(r *RenderRunner, results map[string]string, envs Environments, manifestFormat string) error {
+func printRenderProjectWithOptionsSuccess(r *RenderRunner, results map[string]string, envs Environments) error {
 	var namedValues []kmd.NamedValue
 	for _, env := range envs {
 		namedValues = append(namedValues, kmd.NamedValue{Name: env.Name, Value: results[env.Name]})
@@ -255,7 +249,7 @@ func printRenderProjectWithOptionsSuccess(r *RenderRunner, results map[string]st
 	}
 
 	ui.Output(
-		fmt.Sprintf("A set of '%s' manifests have been generated:", manifestFormat),
+		fmt.Sprintf("A set of '%s' manifests have been generated:", r.config.ManifestFormat),
 		kmd.WithStyle(kmd.SuccessStyle),
 	)
 	ui.NamedValues(namedValues, kmd.WithStyle(kmd.SuccessStyle))

--- a/pkg/kev/types.go
+++ b/pkg/kev/types.go
@@ -26,17 +26,30 @@ import (
 
 // runConfig stores configuration for a command
 type runConfig struct {
-	ComposeSources        []string
-	Envs                  []string
-	ManifestFormat        string
+	// ComposeSources is a list of compose files to use
+	ComposeSources []string
+	// Envs is a list of environments to use
+	Envs []string
+	// ManifestFormat is a format of the output manifests
+	ManifestFormat string
+	// ManifestsAsSingleFile indicates whether to render all manifests into a single file
 	ManifestsAsSingleFile bool
-	OutputDir             string
-	K8sNamespace          string
-	Kubecontext           string
-	Skaffold              bool
-	SkaffoldTail          bool
+	// AdditionalManifests is a list of additional manifests that should be added to the generated manifests set
+	AdditionalManifests []string
+	// OutputDir is a directory where to store the generated manifests
+	OutputDir string
+	// K8sNamespace is a target Kubernetes namespace
+	K8sNamespace string
+	// KubeContext is a target Kubernetes cluster context
+	Kubecontext string
+	// Skaffold is a flag indicating whether to generate skaffold.yaml
+	Skaffold bool
+	// SkaffoldTail is a flag indicating whether to tail skaffold logs
+	SkaffoldTail bool
+	// SkaffoldManualTrigger is a flag indicating whether trigger changes manually when skaffold dev loop is running
 	SkaffoldManualTrigger bool
-	SkaffoldVerbose       bool
+	// SkaffoldVerbose is a flag indicating whether to enable verbose logging for skaffold
+	SkaffoldVerbose bool
 	// ExcludeServicesByEnv is used to exclude an environment's set of services from processing.
 	// Primary use is during render.
 	ExcludeServicesByEnv map[string][]string
@@ -69,11 +82,17 @@ type Runner interface {
 // Project is the base struct for all runners.
 // Runners must initialise a project using Init().
 type Project struct {
-	AppName      string
-	WorkingDir   string
-	UI           kmd.UI
-	manifest     *Manifest
-	config       *runConfig
+	// AppName is the application name.
+	AppName string
+	// WorkingDir is the working directory.
+	WorkingDir string
+	// UI is the user interface.
+	UI kmd.UI
+	// manifest is the project manifest containing information on source compose files, environments etc.
+	manifest *Manifest
+	// config is the project configuration.
+	config *runConfig
+	// eventHandler is the event handler.
 	eventHandler EventHandler
 	ctx          context.Context
 }


### PR DESCRIPTION
This PR adds the ability for passing extra manifests to be part of the rendered output for selected or all environments.
One or more custom manifests can be sourced from any path and will be added to the manifests generated based on the compose configuration. 

```sh
kev render -a /some/path/netpol.yaml -a /other/path/ingress.yaml -a local/deployment.yaml
```
In order to add extra manifests to particular environment will require `-e <envname>` to be added to the command above.