### PR TITLE
Skaffold config will preserve Sync sections if defined

### DIFF
--- a/pkg/kev/skaffold.go
+++ b/pkg/kev/skaffold.go
@@ -345,10 +345,19 @@ func (s *SkaffoldManifest) AddProfileIfNotPresent(p latest.Profile) {
 func (s *SkaffoldManifest) SetBuildArtifacts(analysis *Analysis, project *ComposeProject) {
 	artifacts := []*latest.Artifact{}
 
+	existingArtifacts := s.Build.Artifacts
+
 	for context, image := range collectBuildArtifacts(analysis, project) {
 		artifact := &latest.Artifact{
 			ImageName: image,
 			Workspace: context,
+		}
+
+		// if skaffold contains sync rules for particular artifact, we need to preserve them
+		for _, a := range existingArtifacts {
+			if a.ImageName == image && a.Workspace == context && a.Sync != nil {
+				artifact.Sync = a.Sync
+			}
 		}
 
 		if analysis == nil || analysis.Dockerfiles == nil || len(analysis.Dockerfiles) == 0 {


### PR DESCRIPTION
Any file syncing rules that may have been manually added to the `skaffold.yaml` manifest will now be preserved for each respective build artefact. Previously `render` and `dev` subcommands would strip `sync` block entirely.

Example: 
```yaml
apiVersion: skaffold/v2beta14
kind: Config
metadata:
  name: App
build:
  artifacts:
    - image: myregistry.example.com/org/repo
      context: app
      sync:    # <---- manually added file syncing block will now be preserved with `kev render` / `kev dev` commands.
        manual:
          - src: src/**/*
            dest: /app
  tagPolicy:
    gitCommit:
      variant: Tags
  local: {}
```