### PR TITLE
Update nightly e2e image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
   e2e:
     machine:
       docker_layer_caching: true
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2204:2022.10.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Nightly e2e has been failing for a while now due to image that is now unavailable.