### PR TITLE
Fix nightly e2e pipeline

### DIFF
--- a/e2e/helper.bash
+++ b/e2e/helper.bash
@@ -90,7 +90,7 @@ check-app-is-running(){
   local port=$3
 
   podname=$($KUBECTL get pod -n "${namespace}" -l "${label}" -o name)
-  attempt 60 5 "$KUBECTL -n ${namespace} exec ${podname} --  curl -sLI localhost:${port}"
+  attempt 60 5 "$KUBECTL -n ${namespace} exec ${podname} --  curl -sLI localhost:${port} | grep '200 OK'"
 }
 
 attempt() {


### PR DESCRIPTION
I suspect bats behaviour has changed in the meantime when it comes to multiline output. This patch should make it more resilient to change moving forward, until e2e is replaced with something else.